### PR TITLE
refactor of api

### DIFF
--- a/cmd/apiserver/main.go
+++ b/cmd/apiserver/main.go
@@ -1,98 +1,137 @@
 package main
 
 import (
-    "context"
-    "fmt"
-    "os"
+	"context"
+	"fmt"
+	"os"
+	"time"
 
-    "github.com/urfave/cli"
-    "github.com/spacemeshos/go-spacemesh/log"
-    "github.com/spacemeshos/explorer-backend/api"
+	"github.com/spacemeshos/go-spacemesh/log"
+	"github.com/urfave/cli"
+
+	"github.com/spacemeshos/explorer-backend/api"
+	"github.com/spacemeshos/explorer-backend/internal/router"
+	appService "github.com/spacemeshos/explorer-backend/internal/service"
+	"github.com/spacemeshos/explorer-backend/internal/storage/storagereader"
 )
 
 var (
-    version string
-    commit  string
-    branch  string
+	version string
+	commit  string
+	branch  string
 )
 
 var (
-    listenStringFlag      string
-    mongoDbUrlStringFlag  string
-    mongoDbNameStringFlag string
+	listenStringFlag      string
+	mongoDbURLStringFlag  string
+	mongoDbNameStringFlag string
 )
 
 var flags = []cli.Flag{
-    cli.StringFlag{
-        Name:        "listen",
-        Usage:       "Explorer API listen string in format <host>:<port>",
-        Required:    false,
-        Destination: &listenStringFlag,
-        Value:       ":5000",
-    },
-    cli.StringFlag{
-        Name:        "mongodb",
-        Usage:       "Explorer MongoDB Uri string in format mongodb://<host>:<port>",
-        Required:    false,
-        Destination: &mongoDbUrlStringFlag,
-        Value:       "mongodb://localhost:27017",
-    },
-    cli.StringFlag{
-        Name:        "db",
-        Usage:       "MongoDB Explorer database name string",
-        Required:    false,
-        Destination: &mongoDbNameStringFlag,
-        Value:       "explorer",
-    },
+	cli.StringFlag{
+		Name:        "listen",
+		Usage:       "Explorer API listen string in format <host>:<port>",
+		Required:    false,
+		Destination: &listenStringFlag,
+		Value:       ":5000",
+	},
+	cli.StringFlag{
+		Name:        "mongodb",
+		Usage:       "Explorer MongoDB Uri string in format mongodb://<host>:<port>",
+		Required:    false,
+		Destination: &mongoDbURLStringFlag,
+		Value:       "mongodb://localhost:27017",
+	},
+	cli.StringFlag{
+		Name:        "db",
+		Usage:       "MongoDB Explorer database name string",
+		Required:    false,
+		Destination: &mongoDbNameStringFlag,
+		Value:       "explorer",
+	},
 }
 
 func main() {
-    app := cli.NewApp()
-    app.Name = "Spacemesh Explorer REST API Server"
-    app.Version = fmt.Sprintf("%s, commit '%s', branch '%s'", version, commit, branch)
-    app.Flags = flags
-    app.Writer = os.Stderr
+	app := cli.NewApp()
+	app.Name = "Spacemesh Explorer REST API Server"
+	app.Version = fmt.Sprintf("%s, commit '%s', branch '%s'", version, commit, branch)
+	app.Flags = flags
+	app.Writer = os.Stderr
 
-    app.Action = func(ctx *cli.Context) (error) {
+	env, ok := os.LookupEnv("SPACEMESH_API_LISTEN")
+	if ok {
+		listenStringFlag = env
+	}
+	env, ok = os.LookupEnv("SPACEMESH_MONGO_URI")
+	if ok {
+		mongoDbURLStringFlag = env
+	}
+	env, ok = os.LookupEnv("SPACEMESH_MONGO_DB")
+	if ok {
+		mongoDbNameStringFlag = env
+	}
 
-        env, ok := os.LookupEnv("SPACEMESH_API_LISTEN")
-        if ok {
-            listenStringFlag = env
-        }
-        env, ok = os.LookupEnv("SPACEMESH_MONGO_URI")
-        if ok {
-            mongoDbUrlStringFlag = env
-        }
-        env, ok = os.LookupEnv("SPACEMESH_MONGO_DB")
-        if ok {
-            mongoDbNameStringFlag = env
-        }
+	mongoDbURLStringFlag = "mongodb://localhost:27017"
+	mongoDbNameStringFlag = "explorer"
+	flag := true // flag switch old|new router.
 
-        serverCfg := &api.Config{
-            ListenOn:     listenStringFlag,
-            DbUrl:        mongoDbUrlStringFlag,
-            DbName:       mongoDbNameStringFlag,
-        }
+	app.Action = func(ctx *cli.Context) error {
+		if flag {
+			if err := newApp(mongoDbURLStringFlag, mongoDbNameStringFlag, listenStringFlag); err != nil {
+				log.Error("error start service", err.Error())
+				return err
+			}
+		} else {
+			if err := oldApp(mongoDbURLStringFlag, mongoDbNameStringFlag, listenStringFlag); err != nil {
+				log.Error("error start service", err.Error())
+				return err
+			}
+		}
 
-        server, err := api.New(context.Background(), serverCfg)
-        if err != nil {
-            log.Info("%+v", err)
-            return err
-        }
+		log.Info("Server is shutdown")
+		return nil
+	}
 
-        if err = server.Run(); err != nil {
-            log.Info("%+v", err)
-            return err
-        }
+	if err := app.Run(os.Args); err != nil {
+		log.Info("%v", err)
+		os.Exit(1)
+	}
 
-        log.Info("Server is shutdown")
-        return nil
-    }
+	os.Exit(0)
+}
 
-    if err := app.Run(os.Args); err != nil {
-        log.Info("%v", err)
-        os.Exit(1)
-    }
+func oldApp(mongoDbURL, mongoDbName, listen string) error {
+	serverCfg := &api.Config{
+		ListenOn: listen,
+		DbUrl:    mongoDbURL,
+		DbName:   mongoDbName,
+	}
 
-    os.Exit(0)
+	server, err := api.New(context.Background(), serverCfg)
+	if err != nil {
+		log.Info("%+v", err)
+		return err
+	}
+
+	if err = server.Run(); err != nil {
+		log.Info("%+v", err)
+		return err
+	}
+	return nil
+}
+
+func newApp(mongoDbURL, mongoDbName, listen string) error {
+	dbReader, err := storagereader.NewStorageReader(context.Background(), mongoDbURL, mongoDbName)
+	if err != nil {
+		return fmt.Errorf("error init storage reader: %w", err)
+	}
+	service := appService.NewService(dbReader, time.Minute)
+	app := router.InitAppRouter(&router.Config{
+		ListenOn: listen,
+	}, service)
+	log.Info(fmt.Sprintf("starting server on %s", listen))
+	if err = app.Run(); err != nil {
+		return fmt.Errorf("error start service: %w", err)
+	}
+	return nil
 }

--- a/cmd/apiserver/main.go
+++ b/cmd/apiserver/main.go
@@ -71,8 +71,6 @@ func main() {
 		mongoDbNameStringFlag = env
 	}
 
-	mongoDbURLStringFlag = "mongodb://localhost:27017"
-	mongoDbNameStringFlag = "explorer"
 	flag := true // flag switch old|new router.
 
 	app.Action = func(ctx *cli.Context) error {

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/spacemeshos/explorer-backend
 go 1.18
 
 require (
+	github.com/gofiber/fiber/v2 v2.36.0
 	github.com/golang/protobuf v1.5.2
 	github.com/gorilla/mux v1.8.0
 	github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5
@@ -16,17 +17,21 @@ require (
 )
 
 require (
+	github.com/andybalholm/brotli v1.0.4 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/golang/snappy v0.0.1 // indirect
 	github.com/google/uuid v1.1.2 // indirect
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0 // indirect
-	github.com/klauspost/compress v1.13.6 // indirect
+	github.com/klauspost/compress v1.15.0 // indirect
 	github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/russross/blackfriday/v2 v2.0.1 // indirect
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
+	github.com/valyala/bytebufferpool v1.0.0 // indirect
+	github.com/valyala/fasthttp v1.38.0 // indirect
+	github.com/valyala/tcplisten v1.0.0 // indirect
 	github.com/xdg-go/pbkdf2 v1.0.0 // indirect
 	github.com/xdg-go/scram v1.1.1 // indirect
 	github.com/xdg-go/stringprep v1.0.3 // indirect
@@ -35,7 +40,7 @@ require (
 	go.uber.org/multierr v1.5.0 // indirect
 	go.uber.org/zap v1.15.0 // indirect
 	golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d // indirect
-	golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2 // indirect
+	golang.org/x/net v0.0.0-20220225172249-27dd8689420f // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 	golang.org/x/sys v0.0.0-20220412211240-33da011f77ad // indirect
 	golang.org/x/text v0.3.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -45,6 +45,8 @@ github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
+github.com/andybalholm/brotli v1.0.4 h1:V7DdXeJtZscaqfNuAdSRuRFzuiKlHSC/Zh3zl9qY3JY=
+github.com/andybalholm/brotli v1.0.4/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
@@ -123,6 +125,8 @@ github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V
 github.com/go-ole/go-ole v1.2.4/go.mod h1:XCwSNxSkXRo4vlyPy93sltvi/qJq0jqQhjqQNIwKuxM=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/gobuffalo/here v0.6.0/go.mod h1:wAG085dHOYqUpf+Ap+WOdrPTp5IYcDAs/x7PLa8Y5fM=
+github.com/gofiber/fiber/v2 v2.36.0 h1:1qLMe5rhXFLPa2SjK10Wz7WFgLwYi4TYg7XrjztJHqA=
+github.com/gofiber/fiber/v2 v2.36.0/go.mod h1:tgCr+lierLwLoVHHO/jn3Niannv34WRkQETU8wiL9fQ=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
@@ -221,8 +225,9 @@ github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvW
 github.com/kisielk/godepgraph v0.0.0-20190626013829-57a7e4a651a9/go.mod h1:Gb5YEgxqiSSVrXKWQxDcKoCM94NO5QAwOwTaVmIUAMI=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kkdai/bstream v0.0.0-20161212061736-f391b8402d23/go.mod h1:J+Gs4SYgM6CZQHDETBtE9HaSEkGmuNXF86RwHhHUvq4=
-github.com/klauspost/compress v1.13.6 h1:P76CopJELS0TiO2mebmnzgWaajssP/EszplttgQxcgc=
 github.com/klauspost/compress v1.13.6/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
+github.com/klauspost/compress v1.15.0 h1:xqfchp4whNFxn5A4XFyyYtitiWI8Hy5EW59jEwcyL6U=
+github.com/klauspost/compress v1.15.0/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
@@ -365,6 +370,12 @@ github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljT
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli v1.22.9 h1:cv3/KhXGBGjEXLC4bH0sLuJ9BewaAbpk5oyMOveu4pw=
 github.com/urfave/cli v1.22.9/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
+github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
+github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
+github.com/valyala/fasthttp v1.38.0 h1:yTjSSNjuDi2PPvXY2836bIwLmiTS2T4T9p1coQshpco=
+github.com/valyala/fasthttp v1.38.0/go.mod h1:t/G+3rLek+CyY9bnIE+YlMRddxVAAGjhxndDB4i4C0I=
+github.com/valyala/tcplisten v1.0.0 h1:rBHj/Xf+E1tRGZyWIWwJDiRY0zc1Js+CV5DqwacVSA8=
+github.com/valyala/tcplisten v1.0.0/go.mod h1:T0xQ8SeCZGxckz9qRXTfG43PvQ/mcWh7FwZEA7Ioqkc=
 github.com/wacul/ptr v0.0.0-20170209030335-91632201dfc8/go.mod h1:BD0gjsZrCwtoR+yWDB9v2hQ8STlq9tT84qKfa+3txOc=
 github.com/wacul/ptr v1.0.0/go.mod h1:BD0gjsZrCwtoR+yWDB9v2hQ8STlq9tT84qKfa+3txOc=
 github.com/xdg-go/pbkdf2 v1.0.0 h1:Su7DPu48wXMwC3bs7MCNG+z4FhcyEuz5dlvchbq0B0c=
@@ -409,6 +420,7 @@ golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20220214200702-86341886e292/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d h1:sK3txAijHtOK88l68nt020reeT1ZdKLIYetKl95FzVY=
 golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -479,8 +491,9 @@ golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81R
 golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200927032502-5d4f70055728/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
-golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2 h1:CIJ76btIcR3eFI5EgSo6k1qKw9KJexJuRLI9G7Hp5wE=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20220225172249-27dd8689420f h1:oA4XRj0qtSt8Yo1Zms0CUlsT3KG69V2UGQWPBxujDmc=
+golang.org/x/net v0.0.0-20220225172249-27dd8689420f/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -548,9 +561,12 @@ golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210228012217-479acdf4ea46/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220227234510-4e6760a101f9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220412211240-33da011f77ad h1:ntjMns5wyP/fN65tdBD4g8J5w8n015+iIIs9rtjXkY0=
 golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/internal/router/accounts.go
+++ b/internal/router/accounts.go
@@ -1,0 +1,49 @@
+package router
+
+import (
+	"fmt"
+
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/spacemeshos/explorer-backend/model"
+)
+
+func (a *AppRouter) accounts(ctx *fiber.Ctx) error {
+	pageNum, pageSize := a.getPagination(ctx)
+	accounts, total, err := a.appService.GetAccounts(ctx.UserContext(), pageNum, pageSize)
+	if err != nil {
+		return fmt.Errorf("failed to get accounts list: %w", err)
+	}
+	return ctx.JSON(fiber.Map{"data": accounts, "pagination": a.setPaginationResponse(total, pageNum, pageSize)})
+}
+
+func (a *AppRouter) account(ctx *fiber.Ctx) error {
+	account, err := a.appService.GetAccount(ctx.UserContext(), ctx.Params("id"))
+	if err != nil {
+		return fmt.Errorf("failed to get account `%s` info: %w", ctx.Params("id"), err)
+	}
+	return ctx.JSON(fiber.Map{"data": []*model.Account{account}})
+}
+
+func (a *AppRouter) accountDetails(ctx *fiber.Ctx) error {
+	pageNum, pageSize := a.getPagination(ctx)
+	accountID := ctx.Params("id")
+	var (
+		response interface{}
+		err      error
+		total    int64
+	)
+
+	switch ctx.Params("entity") {
+	case "txs":
+		response, total, err = a.appService.GetAccountTransactions(ctx.UserContext(), accountID, pageNum, pageSize)
+	case "rewards":
+		response, total, err = a.appService.GetAccountRewards(ctx.UserContext(), accountID, pageNum, pageSize)
+	default:
+		return fiber.NewError(fiber.StatusNotFound, "entity not found")
+	}
+	if err != nil {
+		return fmt.Errorf("failed to get account entity `%s` list: %w", ctx.Params("entity"), err)
+	}
+	return ctx.JSON(fiber.Map{"data": response, "pagination": a.setPaginationResponse(total, pageNum, pageSize)})
+}

--- a/internal/router/accounts.go
+++ b/internal/router/accounts.go
@@ -35,9 +35,9 @@ func (a *AppRouter) accountDetails(ctx *fiber.Ctx) error {
 	)
 
 	switch ctx.Params("entity") {
-	case "txs":
+	case txs:
 		response, total, err = a.appService.GetAccountTransactions(ctx.UserContext(), accountID, pageNum, pageSize)
-	case "rewards":
+	case rewards:
 		response, total, err = a.appService.GetAccountRewards(ctx.UserContext(), accountID, pageNum, pageSize)
 	default:
 		return fiber.NewError(fiber.StatusNotFound, "entity not found")

--- a/internal/router/activations.go
+++ b/internal/router/activations.go
@@ -1,0 +1,26 @@
+package router
+
+import (
+	"fmt"
+
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/spacemeshos/explorer-backend/model"
+)
+
+func (a *AppRouter) activations(ctx *fiber.Ctx) error {
+	pageNum, pageSize := a.getPagination(ctx)
+	atxs, total, err := a.appService.GetActivations(ctx.UserContext(), pageNum, pageSize)
+	if err != nil {
+		return fmt.Errorf("failed to get apps info: %w", err)
+	}
+	return ctx.JSON(fiber.Map{"data": atxs, "pagination": a.setPaginationResponse(total, pageNum, pageSize)})
+}
+
+func (a *AppRouter) activation(ctx *fiber.Ctx) error {
+	atx, err := a.appService.GetActivation(ctx.UserContext(), ctx.Params("id"))
+	if err != nil {
+		return fmt.Errorf("failed to get activation %s info: %w", ctx.Params("id"), err)
+	}
+	return ctx.JSON(fiber.Map{"data": []*model.Activation{atx}})
+}

--- a/internal/router/apps.go
+++ b/internal/router/apps.go
@@ -1,0 +1,26 @@
+package router
+
+import (
+	"fmt"
+
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/spacemeshos/explorer-backend/model"
+)
+
+func (a *AppRouter) apps(ctx *fiber.Ctx) error {
+	pageNum, pageSize := a.getPagination(ctx)
+	apps, total, err := a.appService.GetApps(ctx.UserContext(), pageNum, pageSize)
+	if err != nil {
+		return fmt.Errorf("failed to get apps info: %w", err)
+	}
+	return ctx.JSON(fiber.Map{"data": apps, "pagination": a.setPaginationResponse(total, pageNum, pageSize)})
+}
+
+func (a *AppRouter) app(ctx *fiber.Ctx) error {
+	app, err := a.appService.GetApp(ctx.UserContext(), ctx.Params("id"))
+	if err != nil {
+		return fmt.Errorf("failed to get app `%s` info: %w", ctx.Params("id"), err)
+	}
+	return ctx.JSON(fiber.Map{"data": []*model.App{app}})
+}

--- a/internal/router/base.go
+++ b/internal/router/base.go
@@ -1,0 +1,178 @@
+package router
+
+import (
+	"errors"
+	"net/http"
+	"os"
+	"os/signal"
+	"strconv"
+	"syscall"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/gofiber/fiber/v2/middleware/recover"
+	"github.com/spacemeshos/go-spacemesh/log"
+
+	logger "github.com/spacemeshos/explorer-backend/internal/router/middleware"
+	"github.com/spacemeshos/explorer-backend/internal/service"
+)
+
+// Config is the configuration of the server.
+type Config struct {
+	ListenOn string
+}
+
+// AppRouter is the main router for the app.
+type AppRouter struct {
+	routerTimeout time.Duration
+	conf          *Config
+	appService    service.AppService
+	fiber.Router
+	FiberApp *fiber.App
+}
+
+// InitAppRouter initializes the app router.
+func InitAppRouter(conf *Config, appService service.AppService) *AppRouter {
+	fiberApp := fiber.New(
+		fiber.Config{
+			ErrorHandler: func(ctx *fiber.Ctx, err error) error {
+				log.Error("error get info. path: `%s`, err: %s", ctx.Request().URI().PathOriginal(), err)
+				if errors.Is(err, service.ErrNotFound) {
+					return ctx.Status(http.StatusNotFound).JSON(fiber.Map{"error": "not found"})
+				}
+				return ctx.Status(http.StatusInternalServerError).JSON(fiber.Map{"error": "internal server error"})
+			},
+			DisableStartupMessage: true,
+			ReadBufferSize:        4096 * 16,
+			WriteBufferSize:       4096 * 16,
+			BodyLimit:             100 * 1024 * 1024,
+		},
+	)
+
+	fiberApp.Use(recover.New())
+	fiberApp.Use(logger.New())
+
+	app := &AppRouter{
+		routerTimeout: 5 * time.Second,
+		appService:    appService,
+		conf:          conf,
+		FiberApp:      fiberApp,
+		Router:        fiberApp,
+	}
+	app.initRoutes()
+	return app
+}
+
+func (a *AppRouter) initRoutes() {
+	a.FiberApp.Get("/healthz", a.healthzHandler)
+	a.FiberApp.Get("/synced", a.synced)
+
+	a.FiberApp.Get("/network-info", a.networkInfo)
+
+	a.FiberApp.Get("/epochs", a.epochs)
+	a.FiberApp.Get("/epochs/:id", a.epoch)
+	a.FiberApp.Get("/epochs/:id/:entity", a.epochDetails) // layers, txs, smeshers, rewards, atxs.
+
+	a.FiberApp.Get("/layers", a.layers)
+	a.FiberApp.Get("/layers/:id", a.layer)
+	a.FiberApp.Get("/layers/:id/:entity", a.layerDetails) // txs, smeshers, blocks, rewards, atxs
+
+	a.FiberApp.Get("/smeshers", a.smeshers)
+	a.FiberApp.Get("/smeshers/:id", a.smesher)
+	a.FiberApp.Get("/smeshers/:id/:entity", a.smesherDetails) // atx, rewards
+
+	a.FiberApp.Get("/apps", a.apps)
+	a.FiberApp.Get("/apps/:id", a.app)
+
+	a.FiberApp.Get("/atxs", a.activations)
+	a.FiberApp.Get("/atxs/:id", a.activation)
+
+	a.FiberApp.Get("/txs", a.transactions)
+	a.FiberApp.Get("/txs/:id", a.transaction)
+
+	a.FiberApp.Get("/rewards", a.rewards)
+	a.FiberApp.Get("/rewards/:id", a.reward)
+
+	a.FiberApp.Get("/accounts", a.accounts)
+	a.FiberApp.Get("/accounts/:id", a.account)
+	a.FiberApp.Get("/accounts/:id/:entity", a.accountDetails) // txs, rewards
+
+	a.FiberApp.Get("/blocks/:id", a.block)
+
+	a.FiberApp.Get("/search/:id", a.search)
+}
+
+func (a *AppRouter) getPagination(ctx *fiber.Ctx) (pageNumber, pageSize int64) {
+	pageNumber = 1
+	pageSize = 20
+	if page := ctx.Query("page"); page != "" {
+		pageNumber, _ = strconv.ParseInt(page, 10, 32)
+		if pageNumber <= 0 {
+			pageNumber = 1
+		}
+	}
+	if size := ctx.Query("pagesize"); size != "" {
+		pageSize, _ = strconv.ParseInt(size, 10, 32)
+		if pageSize <= 0 {
+			pageSize = 20
+		}
+	}
+	return pageNumber, pageSize
+}
+
+type pagination struct {
+	TotalCount  int64 `json:"totalCount"`
+	PageCount   int64 `json:"pageCount"`
+	PerPage     int64 `json:"perPage"`
+	Next        int64 `json:"next"`
+	HasNext     bool  `json:"hasNext"`
+	HasPrevious bool  `json:"hasPrevious"`
+	Current     int64 `json:"current"`
+	Previous    int64 `json:"previous"`
+}
+
+func (a *AppRouter) setPaginationResponse(total int64, pageNumber int64, pageSize int64) pagination {
+	pageCount := (total + pageSize - 1) / pageSize
+	result := pagination{
+		TotalCount: total,
+		PageCount:  pageNumber,
+		PerPage:    pageSize,
+		Next:       pageCount,
+		Current:    pageNumber,
+		Previous:   1,
+	}
+	if pageNumber < pageCount {
+		result.Next = pageNumber + 1
+		result.HasNext = true
+	}
+	if pageNumber > 1 {
+		result.Previous = pageNumber - 1
+		result.HasPrevious = true
+	}
+	return result
+}
+
+// Run starts the server.
+func (a *AppRouter) Run() error {
+	log.Info("Server is running. For exit <CTRL-c>")
+	if err := a.FiberApp.Listen(a.conf.ListenOn); err != nil {
+		log.Error("server stopped: %s", err)
+	}
+
+	syscalCh := make(chan os.Signal, 1)
+	signal.Notify(syscalCh, syscall.SIGINT, syscall.SIGTERM)
+
+	select {
+	case s := <-syscalCh:
+		log.Info("Exiting, got signal %v", s)
+		if err := a.Shutdown(); err != nil {
+			log.Error("Error on shutdown: %v", err)
+		}
+		return nil
+	}
+}
+
+// Shutdown gracefully shuts down the server.
+func (a *AppRouter) Shutdown() error {
+	return a.FiberApp.Shutdown()
+}

--- a/internal/router/base.go
+++ b/internal/router/base.go
@@ -17,6 +17,16 @@ import (
 	"github.com/spacemeshos/explorer-backend/internal/service"
 )
 
+const (
+	// list of items to search from GET request.
+	txs      = "txs"
+	atxs     = "atxs"
+	blocks   = "blocks"
+	layers   = "layers"
+	rewards  = "rewards"
+	smeshers = "smeshers"
+)
+
 // Config is the configuration of the server.
 type Config struct {
 	ListenOn string
@@ -39,6 +49,8 @@ func InitAppRouter(conf *Config, appService service.AppService) *AppRouter {
 				log.Error("error get info. path: `%s`, err: %s", ctx.Request().URI().PathOriginal(), err)
 				if errors.Is(err, service.ErrNotFound) {
 					return ctx.Status(http.StatusNotFound).JSON(fiber.Map{"error": "not found"})
+				} else if errors.Is(err, fiber.ErrBadRequest) {
+					return ctx.Status(http.StatusBadRequest).JSON(fiber.Map{"error": "bad request"})
 				}
 				return ctx.Status(http.StatusInternalServerError).JSON(fiber.Map{"error": "internal server error"})
 			},

--- a/internal/router/blocks.go
+++ b/internal/router/blocks.go
@@ -1,0 +1,17 @@
+package router
+
+import (
+	"github.com/gofiber/fiber/v2"
+	"github.com/spacemeshos/go-spacemesh/log"
+
+	"github.com/spacemeshos/explorer-backend/model"
+)
+
+func (a *AppRouter) block(ctx *fiber.Ctx) error {
+	block, err := a.appService.GetBlock(ctx.UserContext(), ctx.Params("id"))
+	if err != nil {
+		log.Error("failed to get block `%s` info: %s", block, err)
+		return err
+	}
+	return ctx.JSON(fiber.Map{"data": []*model.Block{block}})
+}

--- a/internal/router/epochs.go
+++ b/internal/router/epochs.go
@@ -1,0 +1,61 @@
+package router
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/spacemeshos/explorer-backend/model"
+)
+
+func (a *AppRouter) epochs(ctx *fiber.Ctx) error {
+	pageNum, pageSize := a.getPagination(ctx)
+	epochs, epochsTotal, err := a.appService.GetEpochs(ctx.UserContext(), pageNum, pageSize)
+	if err != nil {
+		return fmt.Errorf("failed to get epoch list: %w", err)
+	}
+	return ctx.JSON(fiber.Map{"data": epochs, "pagination": a.setPaginationResponse(epochsTotal, pageNum, pageSize)})
+}
+
+func (a *AppRouter) epoch(ctx *fiber.Ctx) error {
+	layerNum, _ := strconv.Atoi(ctx.Params("id"))
+	epochs, err := a.appService.GetEpoch(ctx.UserContext(), layerNum)
+	if err != nil {
+		return fmt.Errorf("failed to get epoch info: %w", err)
+	}
+	return ctx.JSON(fiber.Map{"data": []*model.Epoch{epochs}})
+}
+
+func (a *AppRouter) epochDetails(ctx *fiber.Ctx) error {
+	pageNum, pageSize := a.getPagination(ctx)
+	epochID, err := strconv.Atoi(ctx.Params("id"))
+	if err != nil {
+		ctx.Status(http.StatusBadRequest)
+		return fmt.Errorf("wrong epoch id: %w", err)
+	}
+	var (
+		response interface{}
+		total    int64
+	)
+
+	switch ctx.Params("entity") {
+	case "layers":
+		response, total, err = a.appService.GetEpochLayers(ctx.UserContext(), epochID, pageNum, pageSize)
+	case "txs":
+		response, total, err = a.appService.GetEpochTransactions(ctx.UserContext(), epochID, pageNum, pageSize)
+	case "smeshers":
+		response, total, err = a.appService.GetEpochSmeshers(ctx.UserContext(), epochID, pageNum, pageSize)
+	case "rewards":
+		response, total, err = a.appService.GetEpochRewards(ctx.UserContext(), epochID, pageNum, pageSize)
+	case "atxs":
+		response, total, err = a.appService.GetEpochActivations(ctx.UserContext(), epochID, pageNum, pageSize)
+	default:
+		return fiber.NewError(fiber.StatusNotFound, "entity not found")
+	}
+	if err != nil {
+		return fmt.Errorf("failed to get epoch entity `%s` list: %w", ctx.Params("entity"), err)
+	}
+	return ctx.JSON(fiber.Map{"data": response, "pagination": a.setPaginationResponse(total, pageNum, pageSize)})
+}

--- a/internal/router/epochs.go
+++ b/internal/router/epochs.go
@@ -20,7 +20,10 @@ func (a *AppRouter) epochs(ctx *fiber.Ctx) error {
 }
 
 func (a *AppRouter) epoch(ctx *fiber.Ctx) error {
-	layerNum, _ := strconv.Atoi(ctx.Params("id"))
+	layerNum, err := strconv.Atoi(ctx.Params("id"))
+	if err != nil {
+		return fiber.ErrBadRequest
+	}
 	epochs, err := a.appService.GetEpoch(ctx.UserContext(), layerNum)
 	if err != nil {
 		return fmt.Errorf("failed to get epoch info: %w", err)
@@ -41,15 +44,15 @@ func (a *AppRouter) epochDetails(ctx *fiber.Ctx) error {
 	)
 
 	switch ctx.Params("entity") {
-	case "layers":
+	case layers:
 		response, total, err = a.appService.GetEpochLayers(ctx.UserContext(), epochID, pageNum, pageSize)
-	case "txs":
+	case txs:
 		response, total, err = a.appService.GetEpochTransactions(ctx.UserContext(), epochID, pageNum, pageSize)
-	case "smeshers":
+	case smeshers:
 		response, total, err = a.appService.GetEpochSmeshers(ctx.UserContext(), epochID, pageNum, pageSize)
-	case "rewards":
+	case rewards:
 		response, total, err = a.appService.GetEpochRewards(ctx.UserContext(), epochID, pageNum, pageSize)
-	case "atxs":
+	case atxs:
 		response, total, err = a.appService.GetEpochActivations(ctx.UserContext(), epochID, pageNum, pageSize)
 	default:
 		return fiber.NewError(fiber.StatusNotFound, "entity not found")

--- a/internal/router/layers.go
+++ b/internal/router/layers.go
@@ -1,0 +1,61 @@
+package router
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/spacemeshos/explorer-backend/model"
+)
+
+func (a *AppRouter) layers(ctx *fiber.Ctx) error {
+	pageNum, pageSize := a.getPagination(ctx)
+	layers, layersTotal, err := a.appService.GetLayers(ctx.UserContext(), pageNum, pageSize)
+	if err != nil {
+		return fmt.Errorf("failed to get epoch list: %w", err)
+	}
+	return ctx.JSON(fiber.Map{"data": layers, "pagination": a.setPaginationResponse(layersTotal, pageNum, pageSize)})
+}
+
+func (a *AppRouter) layer(ctx *fiber.Ctx) error {
+	layerID, _ := strconv.Atoi(ctx.Params("id"))
+	layer, err := a.appService.GetLayer(ctx.UserContext(), layerID)
+	if err != nil {
+		return fmt.Errorf("failed to get layer info: %w", err)
+	}
+	return ctx.JSON(fiber.Map{"data": []*model.Layer{layer}})
+}
+
+func (a *AppRouter) layerDetails(ctx *fiber.Ctx) error {
+	pageNum, pageSize := a.getPagination(ctx)
+	layerID, err := strconv.Atoi(ctx.Params("id"))
+	if err != nil {
+		ctx.Status(http.StatusBadRequest)
+		return fmt.Errorf("wrong layer id: %w", err)
+	}
+	var (
+		response interface{}
+		total    int64
+	)
+
+	switch ctx.Params("entity") {
+	case "blocks":
+		response, total, err = a.appService.GetLayerBlocks(ctx.UserContext(), layerID, pageNum, pageSize)
+	case "txs":
+		response, total, err = a.appService.GetLayerTransactions(ctx.UserContext(), layerID, pageNum, pageSize)
+	case "smeshers":
+		response, total, err = a.appService.GetLayerSmeshers(ctx.UserContext(), layerID, pageNum, pageSize)
+	case "rewards":
+		response, total, err = a.appService.GetLayerRewards(ctx.UserContext(), layerID, pageNum, pageSize)
+	case "atxs":
+		response, total, err = a.appService.GetLayerActivations(ctx.UserContext(), layerID, pageNum, pageSize)
+	default:
+		return fiber.NewError(fiber.StatusNotFound, "entity not found")
+	}
+	if err != nil {
+		return fmt.Errorf("failed to get layer entity `%s` list: %w", ctx.Params("entity"), err)
+	}
+	return ctx.JSON(fiber.Map{"data": response, "pagination": a.setPaginationResponse(total, pageNum, pageSize)})
+}

--- a/internal/router/layers.go
+++ b/internal/router/layers.go
@@ -12,15 +12,19 @@ import (
 
 func (a *AppRouter) layers(ctx *fiber.Ctx) error {
 	pageNum, pageSize := a.getPagination(ctx)
-	layers, layersTotal, err := a.appService.GetLayers(ctx.UserContext(), pageNum, pageSize)
+	layersList, layersTotal, err := a.appService.GetLayers(ctx.UserContext(), pageNum, pageSize)
 	if err != nil {
 		return fmt.Errorf("failed to get epoch list: %w", err)
 	}
-	return ctx.JSON(fiber.Map{"data": layers, "pagination": a.setPaginationResponse(layersTotal, pageNum, pageSize)})
+	return ctx.JSON(fiber.Map{"data": layersList, "pagination": a.setPaginationResponse(layersTotal, pageNum, pageSize)})
 }
 
 func (a *AppRouter) layer(ctx *fiber.Ctx) error {
-	layerID, _ := strconv.Atoi(ctx.Params("id"))
+	layerID, err := strconv.Atoi(ctx.Params("id"))
+	if err != nil {
+		ctx.Status(http.StatusBadRequest)
+		return fiber.ErrBadRequest
+	}
 	layer, err := a.appService.GetLayer(ctx.UserContext(), layerID)
 	if err != nil {
 		return fmt.Errorf("failed to get layer info: %w", err)
@@ -41,15 +45,15 @@ func (a *AppRouter) layerDetails(ctx *fiber.Ctx) error {
 	)
 
 	switch ctx.Params("entity") {
-	case "blocks":
+	case blocks:
 		response, total, err = a.appService.GetLayerBlocks(ctx.UserContext(), layerID, pageNum, pageSize)
-	case "txs":
+	case txs:
 		response, total, err = a.appService.GetLayerTransactions(ctx.UserContext(), layerID, pageNum, pageSize)
-	case "smeshers":
+	case smeshers:
 		response, total, err = a.appService.GetLayerSmeshers(ctx.UserContext(), layerID, pageNum, pageSize)
-	case "rewards":
+	case rewards:
 		response, total, err = a.appService.GetLayerRewards(ctx.UserContext(), layerID, pageNum, pageSize)
-	case "atxs":
+	case atxs:
 		response, total, err = a.appService.GetLayerActivations(ctx.UserContext(), layerID, pageNum, pageSize)
 	default:
 		return fiber.NewError(fiber.StatusNotFound, "entity not found")

--- a/internal/router/middleware/config.go
+++ b/internal/router/middleware/config.go
@@ -1,0 +1,34 @@
+package logger
+
+import "github.com/gofiber/fiber/v2"
+
+// Config defines the config for middleware.
+type Config struct {
+	// Next defines a function to skip this middleware when returned true.
+	//
+	// Optional. Default: nil
+	Next func(c *fiber.Ctx) bool
+}
+
+// ConfigDefault is the default config.
+var ConfigDefault = Config{
+	Next: nil,
+}
+
+// Helper function to set default values.
+func configDefault(config ...Config) Config {
+	// Return default config if nothing provided
+	if len(config) < 1 {
+		return ConfigDefault
+	}
+
+	// Override default config
+	cfg := config[0]
+
+	// Set default values
+	if cfg.Next == nil {
+		cfg.Next = ConfigDefault.Next
+	}
+
+	return cfg
+}

--- a/internal/router/middleware/logger.go
+++ b/internal/router/middleware/logger.go
@@ -1,0 +1,43 @@
+package logger
+
+import (
+	"sync"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/spacemeshos/go-spacemesh/log"
+)
+
+// New creates a new middleware handler.
+func New(config ...Config) fiber.Handler {
+	// Set default config
+	cfg := configDefault(config...)
+
+	// Set variables
+	var (
+		once       sync.Once
+		errHandler fiber.ErrorHandler
+	)
+
+	// Return new handler
+	return func(ctx *fiber.Ctx) (err error) {
+		// Don't execute middleware if Next returns true
+		if cfg.Next != nil && cfg.Next(ctx) {
+			return ctx.Next()
+		}
+
+		once.Do(func() {
+			errHandler = ctx.App().ErrorHandler
+		})
+
+		// Handle request, store err for logging
+		chainErr := ctx.Next()
+
+		// Manually call error handler
+		if chainErr != nil {
+			_ = errHandler(ctx, chainErr)
+		}
+		log.Info("%s [%d] - %s", time.Now().Format(time.RFC3339), ctx.Response().StatusCode(), ctx.Request().URI().PathOriginal())
+		return nil
+	}
+}

--- a/internal/router/network_info.go
+++ b/internal/router/network_info.go
@@ -1,0 +1,40 @@
+package router
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+func (a *AppRouter) healthzHandler(ctx *fiber.Ctx) error {
+	if err := a.appService.Ping(ctx.UserContext()); err != nil {
+		return fiber.NewError(fiber.StatusServiceUnavailable, err.Error())
+	}
+	return ctx.SendString("OK")
+}
+
+func (a *AppRouter) synced(ctx *fiber.Ctx) error {
+	networkInfo, err := a.appService.GetNetworkInfo(ctx.UserContext())
+	if err != nil {
+		return fmt.Errorf("failed to check is synced: %w", err)
+	}
+	status := "SYNCED"
+	if !networkInfo.IsSynced {
+		ctx.Status(http.StatusTooEarly)
+		status = "SYNCING"
+	}
+	return ctx.SendString(status)
+}
+
+func (a *AppRouter) networkInfo(ctx *fiber.Ctx) error {
+	networkInfo, epoch, layer, err := a.appService.GetState(ctx.UserContext())
+	if err != nil {
+		return fmt.Errorf("failed to get current state info: %w", err)
+	}
+	return ctx.JSON(fiber.Map{
+		"network": networkInfo,
+		"layer":   layer,
+		"epoch":   epoch,
+	})
+}

--- a/internal/router/rewards.go
+++ b/internal/router/rewards.go
@@ -1,0 +1,26 @@
+package router
+
+import (
+	"fmt"
+
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/spacemeshos/explorer-backend/model"
+)
+
+func (a *AppRouter) rewards(ctx *fiber.Ctx) error {
+	pageNum, pageSize := a.getPagination(ctx)
+	rewards, total, err := a.appService.GetRewards(ctx.UserContext(), pageNum, pageSize)
+	if err != nil {
+		return fmt.Errorf("failed to get rewards info: %w", err)
+	}
+	return ctx.JSON(fiber.Map{"data": rewards, "pagination": a.setPaginationResponse(total, pageNum, pageSize)})
+}
+
+func (a *AppRouter) reward(ctx *fiber.Ctx) error {
+	reward, err := a.appService.GetReward(ctx.UserContext(), ctx.Params("id"))
+	if err != nil {
+		return fmt.Errorf("failed to get reward `%s` info: %w", ctx.Params("id"), err)
+	}
+	return ctx.JSON(fiber.Map{"data": []*model.Reward{reward}})
+}

--- a/internal/router/search.go
+++ b/internal/router/search.go
@@ -1,0 +1,17 @@
+package router
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+func (a *AppRouter) search(ctx *fiber.Ctx) error {
+	search := strings.ToLower(ctx.Params("id"))
+	redirectURL, err := a.appService.Search(ctx.UserContext(), search)
+	if err != nil {
+		return fmt.Errorf("error search `%s`: %w", search, err)
+	}
+	return ctx.JSON(fiber.Map{"redirect": redirectURL})
+}

--- a/internal/router/smeshers.go
+++ b/internal/router/smeshers.go
@@ -35,9 +35,9 @@ func (a *AppRouter) smesherDetails(ctx *fiber.Ctx) error {
 	)
 	pageNum, pageSize := a.getPagination(ctx)
 	switch ctx.Params("entity") {
-	case "atxs":
+	case atxs:
 		response, total, err = a.appService.GetSmesherActivations(ctx.UserContext(), ctx.Params("id"), pageNum, pageSize)
-	case "rewards":
+	case rewards:
 		response, total, err = a.appService.GetSmesherRewards(ctx.UserContext(), ctx.Params("id"), pageNum, pageSize)
 	default:
 		return fiber.NewError(fiber.StatusNotFound, "entity not found")

--- a/internal/router/smeshers.go
+++ b/internal/router/smeshers.go
@@ -1,0 +1,50 @@
+package router
+
+import (
+	"fmt"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/spacemeshos/go-spacemesh/log"
+
+	"github.com/spacemeshos/explorer-backend/model"
+)
+
+func (a *AppRouter) smeshers(ctx *fiber.Ctx) error {
+	pageNum, pageSize := a.getPagination(ctx)
+	smeshers, total, err := a.appService.GetSmeshers(ctx.UserContext(), pageNum, pageSize)
+	if err != nil {
+		log.Error("failed to get smeshers list: %s", err)
+		return err
+	}
+	return ctx.JSON(fiber.Map{"data": smeshers, "pagination": a.setPaginationResponse(total, pageNum, pageSize)})
+}
+
+func (a *AppRouter) smesher(ctx *fiber.Ctx) error {
+	smesher, err := a.appService.GetSmesher(ctx.UserContext(), ctx.Params("id"))
+	if err != nil {
+		return fmt.Errorf("failed to get smesher: %w", err)
+	}
+	return ctx.JSON(fiber.Map{"data": []*model.Smesher{smesher}})
+}
+
+func (a *AppRouter) smesherDetails(ctx *fiber.Ctx) error {
+	var (
+		response interface{}
+		err      error
+		total    int64
+	)
+	pageNum, pageSize := a.getPagination(ctx)
+	switch ctx.Params("entity") {
+	case "atxs":
+		response, total, err = a.appService.GetSmesherActivations(ctx.UserContext(), ctx.Params("id"), pageNum, pageSize)
+	case "rewards":
+		response, total, err = a.appService.GetSmesherRewards(ctx.UserContext(), ctx.Params("id"), pageNum, pageSize)
+	default:
+		return fiber.NewError(fiber.StatusNotFound, "entity not found")
+	}
+	if err != nil {
+		log.Error("failed to get smesher entity `%s` details: %s", ctx.Params("entity"), err)
+		return err
+	}
+	return ctx.JSON(fiber.Map{"data": response, "pagination": a.setPaginationResponse(total, pageNum, pageSize)})
+}

--- a/internal/router/transactions.go
+++ b/internal/router/transactions.go
@@ -1,0 +1,26 @@
+package router
+
+import (
+	"fmt"
+
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/spacemeshos/explorer-backend/model"
+)
+
+func (a *AppRouter) transactions(ctx *fiber.Ctx) error {
+	pageNum, pageSize := a.getPagination(ctx)
+	txs, total, err := a.appService.GetTransactions(ctx.UserContext(), pageNum, pageSize)
+	if err != nil {
+		return fmt.Errorf("failed to get transactions list: %w", err)
+	}
+	return ctx.JSON(fiber.Map{"data": txs, "pagination": a.setPaginationResponse(total, pageNum, pageSize)})
+}
+
+func (a *AppRouter) transaction(ctx *fiber.Ctx) error {
+	tx, err := a.appService.GetTransaction(ctx.UserContext(), ctx.Params("id"))
+	if err != nil {
+		return fmt.Errorf("failed to get transaction %s list: %s", ctx.Params("id"), err)
+	}
+	return ctx.JSON(fiber.Map{"data": []*model.Transaction{tx}})
+}

--- a/internal/service/abstract.go
+++ b/internal/service/abstract.go
@@ -1,0 +1,29 @@
+package service
+
+import (
+	"context"
+	"errors"
+
+	"github.com/spacemeshos/explorer-backend/model"
+)
+
+// ErrNotFound is returned when a resource is not found. Router will serve 404 error if this is returned.
+var ErrNotFound = errors.New("not found")
+
+// AppService is an interface for interacting with the app collection.
+type AppService interface {
+	GetState(ctx context.Context) (*model.NetworkInfo, *model.Epoch, *model.Layer, error)
+	GetNetworkInfo(ctx context.Context) (*model.NetworkInfo, error)
+	Search(ctx context.Context, search string) (string, error)
+	Ping(ctx context.Context) error
+
+	model.EpochService
+	model.LayerService
+	model.SmesherService
+	model.AccountService
+	model.RewardService
+	model.TransactionService
+	model.ActivationService
+	model.AppService
+	model.BlockService
+}

--- a/internal/service/account.go
+++ b/internal/service/account.go
@@ -1,0 +1,112 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo/options"
+
+	"github.com/spacemeshos/explorer-backend/model"
+)
+
+// GetAccount returns account by id.
+func (e *Service) GetAccount(ctx context.Context, accountID string) (*model.Account, error) {
+	idStr := model.ToCheckedAddress(strings.ToLower(accountID))
+	if idStr == "" {
+		return nil, ErrNotFound
+	}
+
+	filter := &bson.D{{"address", idStr}}
+	accs, total, err := e.getAccounts(ctx, filter, options.Find().SetSort(bson.D{{"address", 1}}).SetLimit(1).SetProjection(bson.D{
+		{"_id", 0},
+		{"layer", 0},
+	}))
+	if err != nil {
+		return nil, fmt.Errorf("error find account: %w", err)
+	}
+	if total == 0 {
+		return nil, ErrNotFound
+	}
+	acc := accs[0]
+	summary, err := e.storage.GetAccountSummary(ctx, acc.Address)
+	if err != nil {
+		return nil, fmt.Errorf("error get account summary: %w", err)
+	}
+
+	if summary != nil {
+		acc.Sent = summary.Sent
+		acc.Received = summary.Received
+		acc.Awards = summary.Awards
+		acc.Fees = summary.Fees
+		acc.LayerTms = summary.LayerTms
+	}
+
+	if acc.LayerTms == 0 {
+		net, err := e.GetNetworkInfo(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("error get network info for acc summury: %w", err)
+		}
+		acc.LayerTms = int32(net.GenesisTime)
+	}
+
+	acc.Txs, err = e.storage.CountTransactions(ctx, &bson.D{
+		{"$or", bson.A{
+			bson.D{{"sender", acc.Address}},
+			bson.D{{"receiver", acc.Address}},
+		}},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error count transactions: %w", err)
+	}
+	return acc, nil
+}
+
+// GetAccounts returns accounts by filter.
+func (e *Service) GetAccounts(ctx context.Context, page, perPage int64) ([]*model.Account, int64, error) {
+	return e.getAccounts(ctx, &bson.D{}, e.getFindOptions("layer", page, perPage).SetProjection(bson.D{
+		{"_id", 0},
+		{"layer", 0},
+	}))
+}
+
+// GetAccountTransactions returns transactions by account id.
+func (e *Service) GetAccountTransactions(ctx context.Context, accountID string, page, perPage int64) ([]*model.Transaction, int64, error) {
+	idStr := model.ToCheckedAddress(strings.ToLower(accountID))
+	if idStr == "" {
+		return nil, 0, ErrNotFound
+	}
+
+	filter := &bson.D{
+		{"$or", bson.A{
+			bson.D{{"sender", idStr}},
+			bson.D{{"receiver", idStr}},
+		}},
+	}
+	return e.getTransactions(ctx, filter, e.getFindOptions("counter", page, perPage))
+}
+
+// GetAccountRewards returns rewards by account id.
+func (e *Service) GetAccountRewards(ctx context.Context, accountID string, page, perPage int64) ([]*model.Reward, int64, error) {
+	idStr := model.ToCheckedAddress(strings.ToLower(accountID))
+	if idStr == "" {
+		return nil, 0, ErrNotFound
+	}
+	return e.getRewards(ctx, &bson.D{{"coinbase", idStr}}, e.getFindOptions("coinbase", page, perPage))
+}
+
+func (e *Service) getAccounts(ctx context.Context, filter *bson.D, options *options.FindOptions) (accs []*model.Account, total int64, err error) {
+	total, err = e.storage.CountAccounts(ctx, filter)
+	if err != nil {
+		return nil, 0, fmt.Errorf("error count accounts: %w", err)
+	}
+	if total == 0 {
+		return []*model.Account{}, 0, nil
+	}
+	accs, err = e.storage.GetAccounts(ctx, filter, options)
+	if err != nil {
+		return nil, 0, fmt.Errorf("error get accounts: %w", err)
+	}
+	return accs, total, nil
+}

--- a/internal/service/activation.go
+++ b/internal/service/activation.go
@@ -1,0 +1,42 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo/options"
+
+	"github.com/spacemeshos/explorer-backend/model"
+)
+
+// GetActivations returns atxs by filter.
+func (e *Service) GetActivations(ctx context.Context, page, perPage int64) (atxs []*model.Activation, total int64, err error) {
+	return e.getActivations(ctx, &bson.D{}, e.getFindOptions("id", page, perPage))
+}
+
+// GetActivation returns atx by id.
+func (e *Service) GetActivation(ctx context.Context, activationID string) (*model.Activation, error) {
+	filter := &bson.D{{"id", strings.ToLower(activationID)}}
+	atx, total, err := e.getActivations(ctx, filter, options.Find().SetLimit(1).SetProjection(bson.D{{"_id", 0}}))
+	if err != nil {
+		return nil, fmt.Errorf("error find atx: %w", err)
+	}
+	if total == 0 {
+		return nil, ErrNotFound
+	}
+	return atx[0], nil
+}
+
+func (e *Service) getActivations(ctx context.Context, filter *bson.D, options *options.FindOptions) (atxs []*model.Activation, total int64, err error) {
+	total, err = e.storage.CountActivations(ctx, filter)
+	if err != nil {
+		return nil, 0, fmt.Errorf("error count atxs: %w", err)
+	}
+	atxs, err = e.storage.GetActivations(ctx, filter, options)
+	if err != nil {
+		return nil, 0, fmt.Errorf("error get atxs: %w", err)
+	}
+	return atxs, total, nil
+}

--- a/internal/service/app.go
+++ b/internal/service/app.go
@@ -1,0 +1,44 @@
+package service
+
+import (
+	"context"
+	"fmt"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo/options"
+
+	"github.com/spacemeshos/explorer-backend/model"
+)
+
+// GetApps returns apps by filter.
+func (e *Service) GetApps(ctx context.Context, page, pageSize int64) (apps []*model.App, total int64, err error) {
+	return e.getApps(ctx, &bson.D{}, e.getFindOptions("address", page, pageSize))
+}
+
+// GetApp returns app by address.
+func (e *Service) GetApp(ctx context.Context, appID string) (*model.App, error) {
+	filter := &bson.D{{"address", appID}}
+	apps, _, err := e.getApps(ctx, filter, options.Find().SetLimit(1).SetProjection(bson.D{{"_id", 0}}))
+	if err != nil {
+		return nil, fmt.Errorf("error find app: %w", err)
+	}
+	if len(apps) == 0 {
+		return nil, ErrNotFound
+	}
+	return apps[0], nil
+}
+
+func (e *Service) getApps(ctx context.Context, filter *bson.D, options *options.FindOptions) (apps []*model.App, total int64, err error) {
+	total, err = e.storage.CountApps(ctx, filter)
+	if err != nil {
+		return nil, 0, fmt.Errorf("error count apps: %w", err)
+	}
+	if total == 0 {
+		return []*model.App{}, 0, nil
+	}
+	apps, err = e.storage.GetApps(ctx, filter, options)
+	if err != nil {
+		return nil, 0, fmt.Errorf("error get apps: %w", err)
+	}
+	return apps, total, nil
+}

--- a/internal/service/block.go
+++ b/internal/service/block.go
@@ -1,0 +1,39 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo/options"
+
+	"github.com/spacemeshos/explorer-backend/model"
+)
+
+// GetBlock returns block by id.
+func (e *Service) GetBlock(ctx context.Context, blockID string) (*model.Block, error) {
+	blocks, _, err := e.getBlocks(ctx, &bson.D{{"id", strings.ToLower(blockID)}}, options.Find().SetLimit(1).SetProjection(bson.D{{"_id", 0}}))
+	if err != nil {
+		return nil, fmt.Errorf("error get block by `%s`: %w", blockID, err)
+	}
+	if len(blocks) == 0 {
+		return nil, fmt.Errorf("not found block `%s`", blockID)
+	}
+	return blocks[0], nil
+}
+
+func (e *Service) getBlocks(ctx context.Context, filter *bson.D, options *options.FindOptions) (blocks []*model.Block, total int64, err error) {
+	total, err = e.storage.CountBlocks(ctx, filter)
+	if err != nil {
+		return nil, 0, fmt.Errorf("error count blocks: %w", err)
+	}
+	if total == 0 {
+		return []*model.Block{}, 0, nil
+	}
+	blocks, err = e.storage.GetBlocks(ctx, filter, options)
+	if err != nil {
+		return nil, 0, fmt.Errorf("error get blocks: %w", err)
+	}
+	return blocks, total, nil
+}

--- a/internal/service/epoch.go
+++ b/internal/service/epoch.go
@@ -1,0 +1,115 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo/options"
+
+	"github.com/spacemeshos/explorer-backend/model"
+)
+
+// GetCurrentEpoch returns current epoch.
+func (e *Service) GetCurrentEpoch(ctx context.Context) (*model.Epoch, error) {
+	e.currentEpochMU.RLock()
+	epoch := e.currentEpoch
+	loadTime := e.currentEpochLoaded
+	e.currentEpochMU.RUnlock()
+	if epoch == nil || loadTime.Add(e.cacheTTL).Unix() < time.Now().Unix() {
+		epochs, err := e.storage.GetEpochs(ctx, &bson.D{}, options.Find().SetSort(bson.D{{"number", -1}}).SetLimit(1).SetProjection(bson.D{{"_id", 0}}))
+		if err != nil {
+			return nil, fmt.Errorf("failed to get epoch: %w", err)
+		}
+		if len(epochs) == 0 {
+			return nil, nil
+		}
+		epoch = epochs[0]
+
+		e.currentEpochMU.Lock()
+		e.currentEpoch = epoch
+		e.currentEpochLoaded = time.Now()
+		e.currentEpochMU.Unlock()
+	}
+	return epoch, nil
+}
+
+// GetEpoch get epoch by number.
+func (e *Service) GetEpoch(ctx context.Context, epochNum int) (*model.Epoch, error) {
+	epoch, err := e.storage.GetEpoch(ctx, epochNum)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get epoch `%d`: %w", epochNum, err)
+	}
+	if epoch == nil {
+		return nil, ErrNotFound
+	}
+	return epoch, nil
+}
+
+// GetEpochs returns list of epochs.
+func (e *Service) GetEpochs(ctx context.Context, page, perPage int64) ([]*model.Epoch, int64, error) {
+	total, err := e.storage.CountEpochs(ctx, &bson.D{})
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to count total epochs: %w", err)
+	}
+	epochs, err := e.storage.GetEpochs(ctx, &bson.D{}, e.getFindOptions("number", page, perPage))
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to get epochs: %w", err)
+	}
+	return epochs, total, nil
+}
+
+// GetEpochLayers returns layers for the given epoch.
+func (e *Service) GetEpochLayers(ctx context.Context, epochNum int, page, perPage int64) (layers []*model.Layer, total int64, err error) {
+	layerStart, layerEnd := e.getEpochLayers(epochNum)
+	filter := &bson.D{{"number", bson.D{{"$gte", layerStart}, {"$lte", layerEnd}}}}
+	total, err = e.storage.CountLayers(ctx, filter)
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to count layers for epoch `%d`: %w", epochNum, err)
+	}
+	if total == 0 {
+		return []*model.Layer{}, 0, nil
+	}
+
+	layers, err = e.storage.GetLayers(ctx, filter, e.getFindOptions("number", page, perPage))
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to get layers for epoch `%d`: %w", epochNum, err)
+	}
+
+	return layers, total, nil
+}
+
+// GetEpochTransactions returns transactions for the given epoch.
+func (e *Service) GetEpochTransactions(ctx context.Context, epochNum int, page, perPage int64) (txs []*model.Transaction, total int64, err error) {
+	layerStart, layerEnd := e.getEpochLayers(epochNum)
+	filter := &bson.D{{"layer", bson.D{{"$gte", layerStart}, {"$lte", layerEnd}}}}
+	return e.getTransactions(ctx, filter, e.getFindOptions("id", page, perPage))
+}
+
+// GetEpochSmeshers returns smeshers for the given epoch.
+func (e *Service) GetEpochSmeshers(ctx context.Context, epochNum int, page, perPage int64) (smeshers []*model.Smesher, total int64, err error) {
+	layerStart, layerEnd := e.getEpochLayers(epochNum)
+	filter := &bson.D{{"layer", bson.D{{"$gte", layerStart}, {"$lte", layerEnd}}}}
+	return e.getSmeshers(ctx, filter, e.getFindOptions("id", page, perPage).SetProjection(bson.D{
+		{"id", 0},
+		{"layer", 0},
+		{"coinbase", 0},
+		{"prevAtx", 0},
+		{"cSize", 0},
+	}))
+}
+
+// GetEpochRewards returns rewards for the given epoch.
+func (e *Service) GetEpochRewards(ctx context.Context, epochNum int, page, perPage int64) (rewards []*model.Reward, total int64, err error) {
+	layerStart, layerEnd := e.getEpochLayers(epochNum)
+	filter := &bson.D{{"layer", bson.D{{"$gte", layerStart}, {"$lte", layerEnd}}}}
+	return e.getRewards(ctx, filter, e.getFindOptions("smesher", page, perPage))
+}
+
+// GetEpochActivations returns activations for the given epoch.
+func (e *Service) GetEpochActivations(ctx context.Context, epochNum int, page, perPage int64) (atxs []*model.Activation, total int64, err error) {
+	layerStart, layerEnd := e.getEpochLayers(epochNum)
+	filter := &bson.D{{"layer", bson.D{{"$gte", layerStart}, {"$lte", layerEnd}}}}
+	return e.getActivations(ctx, filter, e.getFindOptions("id", page, perPage))
+}

--- a/internal/service/layer.go
+++ b/internal/service/layer.go
@@ -1,0 +1,105 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo/options"
+
+	"github.com/spacemeshos/explorer-backend/model"
+)
+
+// GetCurrentLayer returns current layer.
+func (e *Service) GetCurrentLayer(ctx context.Context) (*model.Layer, error) {
+	e.currentLayerMU.RLock()
+	layer := e.currentLayer
+	loadTime := e.currentLayerLoaded
+	e.currentLayerMU.RUnlock()
+	if layer == nil || loadTime.Add(e.cacheTTL).Unix() < time.Now().Unix() {
+		layers, err := e.storage.GetLayers(ctx, &bson.D{}, options.Find().SetSort(bson.D{{"number", -1}}).SetLimit(1).SetProjection(bson.D{{"_id", 0}}))
+		if err != nil {
+			return nil, fmt.Errorf("error get layers: %s", err)
+		}
+		if len(layers) == 0 {
+			return nil, nil
+		}
+		layer = layers[0]
+
+		e.currentLayerMU.Lock()
+		e.currentLayer = layer
+		e.currentLayerLoaded = time.Now()
+		e.currentLayerMU.Unlock()
+	}
+	return layer, nil
+}
+
+// GetLayer returns layer by number.
+func (e *Service) GetLayer(ctx context.Context, layerNum int) (*model.Layer, error) {
+	layer, err := e.storage.GetLayer(ctx, layerNum)
+	if err != nil {
+		return nil, fmt.Errorf("error get layer %d: %w", layerNum, err)
+	}
+	if layer == nil {
+		return nil, fmt.Errorf("layer %d not found: %w", layerNum, ErrNotFound)
+	}
+	return layer, nil
+}
+
+// GetLayerByHash returns layer by hash.
+func (e *Service) GetLayerByHash(ctx context.Context, layerHash string) (*model.Layer, error) {
+	layers, err := e.storage.GetLayers(ctx, &bson.D{{"hash", layerHash}})
+	if err != nil {
+		return nil, fmt.Errorf("error get layer by hash `%s`: %w", layerHash, err)
+	}
+	if len(layers) == 0 {
+		return nil, ErrNotFound
+	}
+	return layers[0], nil
+}
+
+// GetLayers returns layers.
+func (e *Service) GetLayers(ctx context.Context, page, perPage int64) (layers []*model.Layer, total int64, err error) {
+	total, err = e.storage.CountLayers(ctx, &bson.D{})
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to count total layers: %w", err)
+	}
+	layers, err = e.storage.GetLayers(ctx, &bson.D{}, e.getFindOptions("number", page, perPage))
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to get layers: %w", err)
+	}
+	return layers, total, nil
+}
+
+// GetLayerTransactions returns transactions for layer.
+func (e *Service) GetLayerTransactions(ctx context.Context, layerNum int, page, perPage int64) (txs []*model.Transaction, total int64, err error) {
+	return e.getTransactions(ctx, &bson.D{{"layer", layerNum}}, e.getFindOptions("id", page, perPage))
+}
+
+// GetLayerSmeshers returns smeshers for layer.
+func (e *Service) GetLayerSmeshers(ctx context.Context, layerNum int, page, perPage int64) (smeshers []*model.Smesher, total int64, err error) {
+	filter := &bson.D{{"layer", layerNum}}
+	return e.getSmeshers(ctx, filter, e.getFindOptions("id", page, perPage).SetProjection(bson.D{
+		{"id", 0},
+		{"layer", 0},
+		{"coinbase", 0},
+		{"prevAtx", 0},
+		{"cSize", 0},
+	}))
+}
+
+// GetLayerRewards returns rewards for layer.
+func (e *Service) GetLayerRewards(ctx context.Context, layerNum int, page, perPage int64) (rewards []*model.Reward, total int64, err error) {
+	return e.getRewards(ctx, &bson.D{{"layer", layerNum}}, e.getFindOptions("smesher", page, perPage))
+}
+
+// GetLayerActivations returns activations for layer.
+func (e *Service) GetLayerActivations(ctx context.Context, layerNum int, page, perPage int64) (atxs []*model.Activation, total int64, err error) {
+	return e.getActivations(ctx, &bson.D{{"layer", layerNum}}, e.getFindOptions("id", page, perPage))
+}
+
+// GetLayerBlocks returns blocks for layer.
+func (e *Service) GetLayerBlocks(ctx context.Context, layerNum int, page, perPage int64) (blocks []*model.Block, total int64, err error) {
+	return e.getBlocks(ctx, &bson.D{{"layer", layerNum}}, e.getFindOptions("id", page, perPage))
+}

--- a/internal/service/reward.go
+++ b/internal/service/reward.go
@@ -1,0 +1,43 @@
+package service
+
+import (
+	"context"
+	"fmt"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo/options"
+
+	"github.com/spacemeshos/explorer-backend/model"
+)
+
+// GetReward returns reward by id.
+func (e *Service) GetReward(ctx context.Context, rewardID string) (*model.Reward, error) {
+	reward, err := e.storage.GetReward(ctx, rewardID)
+	if err != nil {
+		return nil, fmt.Errorf("error get reward: %w", err)
+	}
+	if reward == nil {
+		return nil, fmt.Errorf("reward not found `%s`: %w", rewardID, ErrNotFound)
+	}
+	return reward, nil
+}
+
+// GetRewards returns rewards by filter.
+func (e *Service) GetRewards(ctx context.Context, page, perPage int64) ([]*model.Reward, int64, error) {
+	return e.getRewards(ctx, &bson.D{}, options.Find().SetSort(bson.D{{"layer", -1}}).SetLimit(perPage).SetSkip((page-1)*perPage))
+}
+
+func (e *Service) getRewards(ctx context.Context, filter *bson.D, options *options.FindOptions) (rewards []*model.Reward, total int64, err error) {
+	total, err = e.storage.CountRewards(ctx, filter)
+	if err != nil {
+		return nil, 0, fmt.Errorf("error count rewards: %w", err)
+	}
+	if total == 0 {
+		return []*model.Reward{}, 0, nil
+	}
+	rewards, err = e.storage.GetRewards(ctx, filter, options)
+	if err != nil {
+		return nil, 0, fmt.Errorf("error get rewards: %w", err)
+	}
+	return rewards, total, nil
+}

--- a/internal/service/search.go
+++ b/internal/service/search.go
@@ -6,17 +6,22 @@ import (
 	"strconv"
 )
 
+const (
+	accountBlockIDLength      = 42
+	txAtxSmesherLayerIDLength = 66
+)
+
 // Search try guess entity to search and find related one.
 func (e *Service) Search(ctx context.Context, search string) (string, error) {
 	switch len(search) {
-	case 42:
+	case accountBlockIDLength:
 		if acc, _ := e.GetAccount(ctx, search); acc != nil {
 			return "/accounts/" + search, nil
 		}
 		if block, _ := e.GetBlock(ctx, search); block != nil {
 			return "/blocks/" + search, nil
 		}
-	case 66:
+	case txAtxSmesherLayerIDLength:
 		if tx, _ := e.GetTransaction(ctx, search); tx != nil {
 			return "/txs/" + search, nil
 		}

--- a/internal/service/search.go
+++ b/internal/service/search.go
@@ -1,0 +1,57 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+)
+
+// Search try guess entity to search and find related one.
+func (e *Service) Search(ctx context.Context, search string) (string, error) {
+	switch len(search) {
+	case 42:
+		if acc, _ := e.GetAccount(ctx, search); acc != nil {
+			return "/accounts/" + search, nil
+		}
+		if block, _ := e.GetBlock(ctx, search); block != nil {
+			return "/blocks/" + search, nil
+		}
+	case 66:
+		if tx, _ := e.GetTransaction(ctx, search); tx != nil {
+			return "/txs/" + search, nil
+		}
+		if atx, _ := e.GetActivation(ctx, search); atx != nil {
+			return "/atxs/" + search, nil
+		}
+		if smesher, _ := e.GetSmesher(ctx, search); smesher != nil {
+			return "/smeshers/" + search, nil
+		}
+		if layer, _ := e.GetLayerByHash(ctx, search); layer != nil {
+			return fmt.Sprintf("/smeshers/%d", layer.Number), nil
+		}
+	default:
+		if reward, _ := e.GetReward(ctx, search); reward != nil {
+			return "rewards/" + search, nil
+		}
+		id, err := strconv.Atoi(search)
+		if err != nil {
+			return "", ErrNotFound
+		}
+		layer, err := e.GetCurrentLayer(ctx)
+		if err != nil {
+			return "", fmt.Errorf("error get current layer for search: %w", err)
+		}
+		epoch, err := e.GetCurrentEpoch(ctx)
+		if err != nil {
+			return "", fmt.Errorf("error get current epoch for search: %w", err)
+		}
+		if id > int(epoch.Number) {
+			if id <= int(layer.Number) && id > 0 {
+				return fmt.Sprintf("/layers/%d", id), nil
+			}
+		} else if id > 0 {
+			return fmt.Sprintf("/epochs/%d", id), nil
+		}
+	}
+	return "", ErrNotFound
+}

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -1,0 +1,107 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/spacemeshos/go-spacemesh/log"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo/options"
+
+	"github.com/spacemeshos/explorer-backend/internal/storage/storagereader"
+	"github.com/spacemeshos/explorer-backend/model"
+)
+
+// Service main app service which working with database.
+type Service struct {
+	networkInfo       *model.NetworkInfo
+	networkInfoMU     *sync.RWMutex
+	networkInfoLoaded time.Time
+
+	currentEpoch       *model.Epoch
+	currentEpochMU     *sync.RWMutex
+	currentEpochLoaded time.Time
+
+	currentLayer       *model.Layer
+	currentLayerMU     *sync.RWMutex
+	currentLayerLoaded time.Time
+
+	cacheTTL time.Duration
+	storage  *storagereader.StorageReader
+}
+
+// NewService creates new service instance.
+func NewService(storage *storagereader.StorageReader, cacheTTL time.Duration) *Service {
+	service := &Service{
+		storage:        storage,
+		cacheTTL:       cacheTTL,
+		networkInfoMU:  &sync.RWMutex{},
+		currentEpochMU: &sync.RWMutex{},
+		currentLayerMU: &sync.RWMutex{},
+	}
+
+	if _, err := service.GetNetworkInfo(context.Background()); err != nil {
+		log.Error("error load network info: %w", err)
+	}
+	return service
+}
+
+// GetState returns state of the network, current layer and epoch.
+func (e *Service) GetState(ctx context.Context) (*model.NetworkInfo, *model.Epoch, *model.Layer, error) {
+	net, err := e.GetNetworkInfo(ctx)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to get network info: %w", err)
+	}
+	epoch, err := e.GetCurrentEpoch(ctx)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to get epoch: %w", err)
+	}
+	layer, err := e.GetCurrentLayer(ctx)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to get layer: %w", err)
+	}
+	return net, epoch, layer, nil
+}
+
+// GetNetworkInfo returns actual network info. Caches data for some time (see networkInfoTTL).
+func (e *Service) GetNetworkInfo(ctx context.Context) (net *model.NetworkInfo, err error) {
+	e.networkInfoMU.RLock()
+	net = e.networkInfo
+	loadTime := e.networkInfoLoaded
+	e.networkInfoMU.RUnlock()
+	if net == nil || loadTime.Add(e.cacheTTL).Unix() < time.Now().Unix() {
+		net, err = e.storage.GetNetworkInfo(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed get networkInfo: %w", err)
+		}
+		e.networkInfoMU.Lock()
+		e.networkInfo = net
+		e.networkInfoLoaded = time.Now()
+		e.networkInfoMU.Unlock()
+	}
+	return net, nil
+}
+
+func (e *Service) getFindOptions(key string, page, perPage int64) *options.FindOptions {
+	return options.Find().
+		SetSort(bson.D{{key, -1}}).
+		SetLimit(perPage).
+		SetSkip((page - 1) * perPage).
+		SetProjection(bson.D{{"_id", 0}})
+}
+
+func (e *Service) getEpochLayers(epoch int) (uint32, uint32) {
+	e.networkInfoMU.RLock()
+	net := e.networkInfo
+	e.networkInfoMU.RUnlock()
+	start := uint32(epoch) * net.EpochNumLayers
+	end := start + net.EpochNumLayers - 1
+	return start, end
+}
+
+// Ping checks if the database is reachable.
+func (e *Service) Ping(ctx context.Context) error {
+	return e.storage.Ping(ctx)
+}

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -29,13 +29,13 @@ type Service struct {
 	currentLayerLoaded time.Time
 
 	cacheTTL time.Duration
-	storage  *storagereader.StorageReader
+	storage  storagereader.StorageReader
 }
 
 // NewService creates new service instance.
-func NewService(storage *storagereader.StorageReader, cacheTTL time.Duration) *Service {
+func NewService(reader storagereader.StorageReader, cacheTTL time.Duration) *Service {
 	service := &Service{
-		storage:        storage,
+		storage:        reader,
 		cacheTTL:       cacheTTL,
 		networkInfoMU:  &sync.RWMutex{},
 		currentEpochMU: &sync.RWMutex{},

--- a/internal/service/smesher.go
+++ b/internal/service/smesher.go
@@ -1,0 +1,80 @@
+package service
+
+import (
+	"context"
+	"fmt"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo/options"
+
+	"github.com/spacemeshos/explorer-backend/model"
+)
+
+// GetSmesher returns smesher by id.
+func (e *Service) GetSmesher(ctx context.Context, smesherID string) (*model.Smesher, error) {
+	smesher, err := e.storage.GetSmesher(ctx, smesherID)
+	if err != nil {
+		return nil, err
+	}
+	if smesher == nil {
+		return nil, fmt.Errorf("smesher not found `%s`: %w", smesherID, ErrNotFound)
+	}
+	smesher.Rewards, _, err = e.CountSmesherRewards(ctx, smesherID)
+	return smesher, err
+}
+
+// GetSmeshers returns smeshers by filter.
+func (e *Service) GetSmeshers(ctx context.Context, page, perPage int64) (smeshers []*model.Smesher, total int64, err error) {
+	total, err = e.storage.CountSmeshers(ctx, &bson.D{})
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to count total smeshers: %w", err)
+	}
+	if total == 0 {
+		return []*model.Smesher{}, 0, nil
+	}
+	smeshers, err = e.storage.GetSmeshers(ctx, &bson.D{}, e.getFindOptions("id", page, perPage))
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to get smeshers: %w", err)
+	}
+	return smeshers, total, nil
+}
+
+// GetSmesherActivations returns smesher activations by filter.
+func (e *Service) GetSmesherActivations(ctx context.Context, smesherID string, page, perPage int64) (atxs []*model.Activation, total int64, err error) {
+	return e.getActivations(ctx, &bson.D{{"smesher", smesherID}}, e.getFindOptions("id", page, perPage))
+}
+
+// GetSmesherRewards returns smesher rewards by filter.
+func (e *Service) GetSmesherRewards(ctx context.Context, smesherID string, page, perPage int64) (rewards []*model.Reward, total int64, err error) {
+	return e.getRewards(ctx, &bson.D{{"smesher", smesherID}}, e.getFindOptions("layer", page, perPage))
+}
+
+// CountSmesherRewards returns smesher rewards count by filter.
+func (e *Service) CountSmesherRewards(ctx context.Context, smesherID string) (total, count int64, err error) {
+	return e.storage.CountSmesherRewards(ctx, smesherID)
+}
+
+func (e *Service) getSmeshers(ctx context.Context, filter *bson.D, options *options.FindOptions) (smeshers []*model.Smesher, total int64, err error) {
+	atxs, err := e.storage.GetActivations(ctx, filter, options)
+	if err != nil {
+		return nil, 0, fmt.Errorf("error count smeshers: %w", err)
+	}
+
+	smeshersList := make([]string, 0, len(atxs))
+	var lastID string
+	for _, atx := range atxs {
+		if lastID != atx.SmesherId {
+			smeshersList = append(smeshersList, atx.SmesherId)
+			lastID = atx.SmesherId
+		}
+	}
+	total = int64(len(smeshersList))
+	if total == 0 {
+		return []*model.Smesher{}, 0, nil
+	}
+	smeshers, err = e.storage.GetSmeshers(ctx, &bson.D{{"id", bson.M{"$in": smeshersList}}})
+	if err != nil {
+		return nil, 0, fmt.Errorf("error load smeshers: %w", err)
+	}
+	return smeshers, total, nil
+}

--- a/internal/service/transaction.go
+++ b/internal/service/transaction.go
@@ -1,0 +1,45 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo/options"
+
+	"github.com/spacemeshos/explorer-backend/model"
+)
+
+// GetTransaction returns tx by id.
+func (e *Service) GetTransaction(ctx context.Context, txID string) (*model.Transaction, error) {
+	filter := &bson.D{{"id", strings.ToLower(txID)}}
+	txs, total, err := e.getTransactions(ctx, filter, options.Find().SetLimit(1).SetProjection(bson.D{{"_id", 0}}))
+	if err != nil {
+		return nil, fmt.Errorf("error get transaction: %w", err)
+	}
+	if total == 0 {
+		return nil, ErrNotFound
+	}
+	return txs[0], nil
+}
+
+// GetTransactions returns txs by filter.
+func (e *Service) GetTransactions(ctx context.Context, page, perPage int64) (txs []*model.Transaction, total int64, err error) {
+	return e.getTransactions(ctx, &bson.D{}, e.getFindOptions("timestamp", page, perPage))
+}
+
+func (e *Service) getTransactions(ctx context.Context, filter *bson.D, options *options.FindOptions) (txs []*model.Transaction, total int64, err error) {
+	total, err = e.storage.CountTransactions(ctx, filter)
+	if err != nil {
+		return nil, 0, fmt.Errorf("error count txs: %w", err)
+	}
+	if total == 0 {
+		return []*model.Transaction{}, 0, nil
+	}
+	txs, err = e.storage.GetTransactions(ctx, filter, options)
+	if err != nil {
+		return nil, 0, fmt.Errorf("error get txs: %w", err)
+	}
+	return txs, total, nil
+}

--- a/internal/storage/storagereader/abstract.go
+++ b/internal/storage/storagereader/abstract.go
@@ -1,0 +1,49 @@
+package storagereader
+
+import (
+	"context"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo/options"
+
+	"github.com/spacemeshos/explorer-backend/model"
+)
+
+// StorageReader is the interface for the storage reader. Providing ReadOnly methods.
+type StorageReader interface {
+	Ping(ctx context.Context) error
+	GetNetworkInfo(ctx context.Context) (*model.NetworkInfo, error)
+
+	CountTransactions(ctx context.Context, query *bson.D, opts ...*options.CountOptions) (int64, error)
+	GetTransactions(ctx context.Context, query *bson.D, opts ...*options.FindOptions) ([]*model.Transaction, error)
+
+	CountApps(ctx context.Context, query *bson.D, opts ...*options.CountOptions) (int64, error)
+	GetApps(ctx context.Context, query *bson.D, opts ...*options.FindOptions) ([]*model.App, error)
+
+	CountAccounts(ctx context.Context, query *bson.D, opts ...*options.CountOptions) (int64, error)
+	GetAccounts(ctx context.Context, query *bson.D, opts ...*options.FindOptions) ([]*model.Account, error)
+	GetAccountSummary(ctx context.Context, address string) (*model.AccountSummary, error)
+
+	CountActivations(ctx context.Context, query *bson.D, opts ...*options.CountOptions) (int64, error)
+	GetActivations(ctx context.Context, query *bson.D, opts ...*options.FindOptions) ([]*model.Activation, error)
+
+	CountBlocks(ctx context.Context, query *bson.D, opts ...*options.CountOptions) (int64, error)
+	GetBlocks(ctx context.Context, query *bson.D, opts ...*options.FindOptions) ([]*model.Block, error)
+
+	CountEpochs(ctx context.Context, query *bson.D, opts ...*options.CountOptions) (int64, error)
+	GetEpochs(ctx context.Context, query *bson.D, opts ...*options.FindOptions) ([]*model.Epoch, error)
+	GetEpoch(ctx context.Context, epochNumber int) (*model.Epoch, error)
+
+	CountLayers(ctx context.Context, query *bson.D, opts ...*options.CountOptions) (int64, error)
+	GetLayers(ctx context.Context, query *bson.D, opts ...*options.FindOptions) ([]*model.Layer, error)
+	GetLayer(ctx context.Context, layerNumber int) (*model.Layer, error)
+
+	CountRewards(ctx context.Context, query *bson.D, opts ...*options.CountOptions) (int64, error)
+	GetRewards(ctx context.Context, query *bson.D, opts ...*options.FindOptions) ([]*model.Reward, error)
+	GetReward(ctx context.Context, rewardID string) (*model.Reward, error)
+
+	CountSmeshers(ctx context.Context, query *bson.D, opts ...*options.CountOptions) (int64, error)
+	GetSmeshers(ctx context.Context, query *bson.D, opts ...*options.FindOptions) ([]*model.Smesher, error)
+	GetSmesher(ctx context.Context, smesherID string) (*model.Smesher, error)
+	CountSmesherRewards(ctx context.Context, smesherID string) (total, count int64, err error)
+}

--- a/internal/storage/storagereader/accounts.go
+++ b/internal/storage/storagereader/accounts.go
@@ -1,0 +1,68 @@
+package storagereader
+
+import (
+	"context"
+	"fmt"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+
+	"github.com/spacemeshos/explorer-backend/model"
+)
+
+// CountAccounts returns the number of accounts matching the query.
+func (s *StorageReader) CountAccounts(ctx context.Context, query *bson.D, opts ...*options.CountOptions) (int64, error) {
+	return s.db.Collection("accounts").CountDocuments(ctx, query, opts...)
+}
+
+// GetAccounts returns the accounts matching the query.
+func (s *StorageReader) GetAccounts(ctx context.Context, query *bson.D, opts ...*options.FindOptions) ([]*model.Account, error) {
+	cursor, err := s.db.Collection("accounts").Find(ctx, query, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get accounts: %w", err)
+	}
+	var docs []*model.Account
+	if err = cursor.All(ctx, &docs); err != nil {
+		return nil, fmt.Errorf("error decode accounts: %w", err)
+	}
+	return docs, nil
+}
+
+// GetAccountSummary returns the summary of the accounts matching the query. Not all accounts from api have filled this data.
+func (s *StorageReader) GetAccountSummary(ctx context.Context, address string) (*model.AccountSummary, error) {
+	matchStage := bson.D{{"$match", bson.D{{"address", address}}}}
+	groupStage := bson.D{
+		{"$group", bson.D{
+			{"_id", ""},
+			{"sent", bson.D{
+				{"$sum", "$sent"},
+			}},
+			{"received", bson.D{
+				{"$sum", "$received"},
+			}},
+			{"awards", bson.D{
+				{"$sum", "$reward"},
+			}},
+			{"fees", bson.D{
+				{"$sum", "$fee"},
+			}},
+			{"layer", bson.D{
+				{"$max", "$layer"},
+			}},
+		}},
+	}
+
+	cursor, err := s.db.Collection("ledger").Aggregate(ctx, mongo.Pipeline{matchStage, groupStage})
+	if err != nil {
+		return nil, fmt.Errorf("error get account summary: %w", err)
+	}
+	if !cursor.Next(ctx) {
+		return nil, nil
+	}
+	var accSummary model.AccountSummary
+	if err = cursor.Decode(&accSummary); err != nil {
+		return nil, fmt.Errorf("error decode account summary: %w", err)
+	}
+	return &accSummary, nil
+}

--- a/internal/storage/storagereader/accounts.go
+++ b/internal/storage/storagereader/accounts.go
@@ -12,12 +12,12 @@ import (
 )
 
 // CountAccounts returns the number of accounts matching the query.
-func (s *StorageReader) CountAccounts(ctx context.Context, query *bson.D, opts ...*options.CountOptions) (int64, error) {
+func (s *Reader) CountAccounts(ctx context.Context, query *bson.D, opts ...*options.CountOptions) (int64, error) {
 	return s.db.Collection("accounts").CountDocuments(ctx, query, opts...)
 }
 
 // GetAccounts returns the accounts matching the query.
-func (s *StorageReader) GetAccounts(ctx context.Context, query *bson.D, opts ...*options.FindOptions) ([]*model.Account, error) {
+func (s *Reader) GetAccounts(ctx context.Context, query *bson.D, opts ...*options.FindOptions) ([]*model.Account, error) {
 	cursor, err := s.db.Collection("accounts").Find(ctx, query, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get accounts: %w", err)
@@ -30,7 +30,7 @@ func (s *StorageReader) GetAccounts(ctx context.Context, query *bson.D, opts ...
 }
 
 // GetAccountSummary returns the summary of the accounts matching the query. Not all accounts from api have filled this data.
-func (s *StorageReader) GetAccountSummary(ctx context.Context, address string) (*model.AccountSummary, error) {
+func (s *Reader) GetAccountSummary(ctx context.Context, address string) (*model.AccountSummary, error) {
 	matchStage := bson.D{{"$match", bson.D{{"address", address}}}}
 	groupStage := bson.D{
 		{"$group", bson.D{

--- a/internal/storage/storagereader/activation.go
+++ b/internal/storage/storagereader/activation.go
@@ -11,7 +11,7 @@ import (
 )
 
 // CountActivations returns the number of activations matching the query.
-func (s *StorageReader) CountActivations(ctx context.Context, query *bson.D, opts ...*options.CountOptions) (int64, error) {
+func (s *Reader) CountActivations(ctx context.Context, query *bson.D, opts ...*options.CountOptions) (int64, error) {
 	count, err := s.db.Collection("activations").CountDocuments(ctx, query, opts...)
 	if err != nil {
 		return 0, fmt.Errorf("error count activations: %w", err)
@@ -20,7 +20,7 @@ func (s *StorageReader) CountActivations(ctx context.Context, query *bson.D, opt
 }
 
 // GetActivations returns the activations matching the query.
-func (s *StorageReader) GetActivations(ctx context.Context, query *bson.D, opts ...*options.FindOptions) ([]*model.Activation, error) {
+func (s *Reader) GetActivations(ctx context.Context, query *bson.D, opts ...*options.FindOptions) ([]*model.Activation, error) {
 	cursor, err := s.db.Collection("activations").Find(ctx, query, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get activations: %w", err)

--- a/internal/storage/storagereader/activation.go
+++ b/internal/storage/storagereader/activation.go
@@ -1,0 +1,33 @@
+package storagereader
+
+import (
+	"context"
+	"fmt"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo/options"
+
+	"github.com/spacemeshos/explorer-backend/model"
+)
+
+// CountActivations returns the number of activations matching the query.
+func (s *StorageReader) CountActivations(ctx context.Context, query *bson.D, opts ...*options.CountOptions) (int64, error) {
+	count, err := s.db.Collection("activations").CountDocuments(ctx, query, opts...)
+	if err != nil {
+		return 0, fmt.Errorf("error count activations: %w", err)
+	}
+	return count, nil
+}
+
+// GetActivations returns the activations matching the query.
+func (s *StorageReader) GetActivations(ctx context.Context, query *bson.D, opts ...*options.FindOptions) ([]*model.Activation, error) {
+	cursor, err := s.db.Collection("activations").Find(ctx, query, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get activations: %w", err)
+	}
+	var docs []*model.Activation
+	if err = cursor.All(ctx, &docs); err != nil {
+		return nil, fmt.Errorf("error decode activations: %w", err)
+	}
+	return docs, nil
+}

--- a/internal/storage/storagereader/apps.go
+++ b/internal/storage/storagereader/apps.go
@@ -11,7 +11,7 @@ import (
 )
 
 // CountApps returns the number of apps matching the query.
-func (s *StorageReader) CountApps(ctx context.Context, query *bson.D, opts ...*options.CountOptions) (int64, error) {
+func (s *Reader) CountApps(ctx context.Context, query *bson.D, opts ...*options.CountOptions) (int64, error) {
 	count, err := s.db.Collection("apps").CountDocuments(ctx, query, opts...)
 	if err != nil {
 		return 0, fmt.Errorf("error count apps: %w", err)
@@ -20,7 +20,7 @@ func (s *StorageReader) CountApps(ctx context.Context, query *bson.D, opts ...*o
 }
 
 // GetApps returns the apps matching the query.
-func (s *StorageReader) GetApps(ctx context.Context, query *bson.D, opts ...*options.FindOptions) ([]*model.App, error) {
+func (s *Reader) GetApps(ctx context.Context, query *bson.D, opts ...*options.FindOptions) ([]*model.App, error) {
 	cursor, err := s.db.Collection("apps").Find(ctx, query, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get apps: %w", err)

--- a/internal/storage/storagereader/apps.go
+++ b/internal/storage/storagereader/apps.go
@@ -1,0 +1,33 @@
+package storagereader
+
+import (
+	"context"
+	"fmt"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo/options"
+
+	"github.com/spacemeshos/explorer-backend/model"
+)
+
+// CountApps returns the number of apps matching the query.
+func (s *StorageReader) CountApps(ctx context.Context, query *bson.D, opts ...*options.CountOptions) (int64, error) {
+	count, err := s.db.Collection("apps").CountDocuments(ctx, query, opts...)
+	if err != nil {
+		return 0, fmt.Errorf("error count apps: %w", err)
+	}
+	return count, nil
+}
+
+// GetApps returns the apps matching the query.
+func (s *StorageReader) GetApps(ctx context.Context, query *bson.D, opts ...*options.FindOptions) ([]*model.App, error) {
+	cursor, err := s.db.Collection("apps").Find(ctx, query, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get apps: %w", err)
+	}
+	var docs []*model.App
+	if err = cursor.All(ctx, &docs); err != nil {
+		return nil, fmt.Errorf("error decode apps: %w", err)
+	}
+	return docs, nil
+}

--- a/internal/storage/storagereader/blocks.go
+++ b/internal/storage/storagereader/blocks.go
@@ -11,7 +11,7 @@ import (
 )
 
 // CountBlocks returns the number of blocks matching the query.
-func (s *StorageReader) CountBlocks(ctx context.Context, query *bson.D, opts ...*options.CountOptions) (int64, error) {
+func (s *Reader) CountBlocks(ctx context.Context, query *bson.D, opts ...*options.CountOptions) (int64, error) {
 	count, err := s.db.Collection("blocks").CountDocuments(ctx, query, opts...)
 	if err != nil {
 		return 0, fmt.Errorf("error count blocks: %w", err)
@@ -20,7 +20,7 @@ func (s *StorageReader) CountBlocks(ctx context.Context, query *bson.D, opts ...
 }
 
 // GetBlocks returns the blocks matching the query.
-func (s *StorageReader) GetBlocks(ctx context.Context, query *bson.D, opts ...*options.FindOptions) ([]*model.Block, error) {
+func (s *Reader) GetBlocks(ctx context.Context, query *bson.D, opts ...*options.FindOptions) ([]*model.Block, error) {
 	cursor, err := s.db.Collection("blocks").Find(ctx, query, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("error get blocks: %w", err)

--- a/internal/storage/storagereader/blocks.go
+++ b/internal/storage/storagereader/blocks.go
@@ -1,0 +1,34 @@
+package storagereader
+
+import (
+	"context"
+	"fmt"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo/options"
+
+	"github.com/spacemeshos/explorer-backend/model"
+)
+
+// CountBlocks returns the number of blocks matching the query.
+func (s *StorageReader) CountBlocks(ctx context.Context, query *bson.D, opts ...*options.CountOptions) (int64, error) {
+	count, err := s.db.Collection("blocks").CountDocuments(ctx, query, opts...)
+	if err != nil {
+		return 0, fmt.Errorf("error count blocks: %w", err)
+	}
+	return count, nil
+}
+
+// GetBlocks returns the blocks matching the query.
+func (s *StorageReader) GetBlocks(ctx context.Context, query *bson.D, opts ...*options.FindOptions) ([]*model.Block, error) {
+	cursor, err := s.db.Collection("blocks").Find(ctx, query, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("error get blocks: %w", err)
+	}
+
+	var blocks []*model.Block
+	if err = cursor.All(ctx, &blocks); err != nil {
+		return nil, fmt.Errorf("error decode blocks: %w", err)
+	}
+	return blocks, nil
+}

--- a/internal/storage/storagereader/epochs.go
+++ b/internal/storage/storagereader/epochs.go
@@ -11,7 +11,7 @@ import (
 )
 
 // CountEpochs returns the number of epochs matching the query.
-func (s *StorageReader) CountEpochs(ctx context.Context, query *bson.D, opts ...*options.CountOptions) (int64, error) {
+func (s *Reader) CountEpochs(ctx context.Context, query *bson.D, opts ...*options.CountOptions) (int64, error) {
 	count, err := s.db.Collection("epochs").CountDocuments(ctx, query, opts...)
 	if err != nil {
 		return 0, fmt.Errorf("error count epochs: %w", err)
@@ -20,7 +20,7 @@ func (s *StorageReader) CountEpochs(ctx context.Context, query *bson.D, opts ...
 }
 
 // GetEpochs returns the epochs matching the query.
-func (s *StorageReader) GetEpochs(ctx context.Context, query *bson.D, opts ...*options.FindOptions) ([]*model.Epoch, error) {
+func (s *Reader) GetEpochs(ctx context.Context, query *bson.D, opts ...*options.FindOptions) ([]*model.Epoch, error) {
 	cursor, err := s.db.Collection("epochs").Find(ctx, query, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("error get epochs: %w", err)
@@ -33,7 +33,7 @@ func (s *StorageReader) GetEpochs(ctx context.Context, query *bson.D, opts ...*o
 }
 
 // GetEpoch returns the epoch matching the query.
-func (s *StorageReader) GetEpoch(ctx context.Context, epochNumber int) (*model.Epoch, error) {
+func (s *Reader) GetEpoch(ctx context.Context, epochNumber int) (*model.Epoch, error) {
 	cursor, err := s.db.Collection("epochs").Find(ctx, &bson.D{{"number", epochNumber}})
 	if err != nil {
 		return nil, fmt.Errorf("error get epoch `%d`: %w", epochNumber, err)

--- a/internal/storage/storagereader/epochs.go
+++ b/internal/storage/storagereader/epochs.go
@@ -1,0 +1,49 @@
+package storagereader
+
+import (
+	"context"
+	"fmt"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo/options"
+
+	"github.com/spacemeshos/explorer-backend/model"
+)
+
+// CountEpochs returns the number of epochs matching the query.
+func (s *StorageReader) CountEpochs(ctx context.Context, query *bson.D, opts ...*options.CountOptions) (int64, error) {
+	count, err := s.db.Collection("epochs").CountDocuments(ctx, query, opts...)
+	if err != nil {
+		return 0, fmt.Errorf("error count epochs: %w", err)
+	}
+	return count, nil
+}
+
+// GetEpochs returns the epochs matching the query.
+func (s *StorageReader) GetEpochs(ctx context.Context, query *bson.D, opts ...*options.FindOptions) ([]*model.Epoch, error) {
+	cursor, err := s.db.Collection("epochs").Find(ctx, query, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("error get epochs: %w", err)
+	}
+	var epochs []*model.Epoch
+	if err = cursor.All(ctx, &epochs); err != nil {
+		return nil, err
+	}
+	return epochs, nil
+}
+
+// GetEpoch returns the epoch matching the query.
+func (s *StorageReader) GetEpoch(ctx context.Context, epochNumber int) (*model.Epoch, error) {
+	cursor, err := s.db.Collection("epochs").Find(ctx, &bson.D{{"number", epochNumber}})
+	if err != nil {
+		return nil, fmt.Errorf("error get epoch `%d`: %w", epochNumber, err)
+	}
+	if !cursor.Next(ctx) {
+		return nil, nil
+	}
+	var epoch *model.Epoch
+	if err = cursor.Decode(&epoch); err != nil {
+		return nil, fmt.Errorf("error decode epoch `%d`: %w", epochNumber, err)
+	}
+	return epoch, nil
+}

--- a/internal/storage/storagereader/layers.go
+++ b/internal/storage/storagereader/layers.go
@@ -1,0 +1,50 @@
+package storagereader
+
+import (
+	"context"
+	"fmt"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo/options"
+
+	"github.com/spacemeshos/explorer-backend/model"
+)
+
+// CountLayers returns the number of layers matching the query.
+func (s *StorageReader) CountLayers(ctx context.Context, query *bson.D, opts ...*options.CountOptions) (int64, error) {
+	count, err := s.db.Collection("layers").CountDocuments(ctx, query, opts...)
+	if err != nil {
+		return 0, fmt.Errorf("error count layers: %w", err)
+	}
+	return count, nil
+}
+
+// GetLayers returns the layers matching the query.
+func (s *StorageReader) GetLayers(ctx context.Context, query *bson.D, opts ...*options.FindOptions) ([]*model.Layer, error) {
+	cursor, err := s.db.Collection("layers").Find(ctx, query, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("error get layers: %s", err)
+	}
+
+	var layers []*model.Layer
+	if err = cursor.All(ctx, &layers); err != nil {
+		return nil, fmt.Errorf("error decode layers: %s", err)
+	}
+	return layers, nil
+}
+
+// GetLayer returns the layer matching the query.
+func (s *StorageReader) GetLayer(ctx context.Context, layerNumber int) (*model.Layer, error) {
+	cursor, err := s.db.Collection("layers").Find(ctx, &bson.D{{"number", layerNumber}})
+	if err != nil {
+		return nil, fmt.Errorf("error get layer `%d`: %w", layerNumber, err)
+	}
+	if !cursor.Next(ctx) {
+		return nil, nil
+	}
+	var layer *model.Layer
+	if err = cursor.Decode(&layer); err != nil {
+		return nil, fmt.Errorf("error decode layer `%d`: %w", layerNumber, err)
+	}
+	return layer, nil
+}

--- a/internal/storage/storagereader/layers.go
+++ b/internal/storage/storagereader/layers.go
@@ -11,7 +11,7 @@ import (
 )
 
 // CountLayers returns the number of layers matching the query.
-func (s *StorageReader) CountLayers(ctx context.Context, query *bson.D, opts ...*options.CountOptions) (int64, error) {
+func (s *Reader) CountLayers(ctx context.Context, query *bson.D, opts ...*options.CountOptions) (int64, error) {
 	count, err := s.db.Collection("layers").CountDocuments(ctx, query, opts...)
 	if err != nil {
 		return 0, fmt.Errorf("error count layers: %w", err)
@@ -20,7 +20,7 @@ func (s *StorageReader) CountLayers(ctx context.Context, query *bson.D, opts ...
 }
 
 // GetLayers returns the layers matching the query.
-func (s *StorageReader) GetLayers(ctx context.Context, query *bson.D, opts ...*options.FindOptions) ([]*model.Layer, error) {
+func (s *Reader) GetLayers(ctx context.Context, query *bson.D, opts ...*options.FindOptions) ([]*model.Layer, error) {
 	cursor, err := s.db.Collection("layers").Find(ctx, query, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("error get layers: %s", err)
@@ -34,7 +34,7 @@ func (s *StorageReader) GetLayers(ctx context.Context, query *bson.D, opts ...*o
 }
 
 // GetLayer returns the layer matching the query.
-func (s *StorageReader) GetLayer(ctx context.Context, layerNumber int) (*model.Layer, error) {
+func (s *Reader) GetLayer(ctx context.Context, layerNumber int) (*model.Layer, error) {
 	cursor, err := s.db.Collection("layers").Find(ctx, &bson.D{{"number", layerNumber}})
 	if err != nil {
 		return nil, fmt.Errorf("error get layer `%d`: %w", layerNumber, err)

--- a/internal/storage/storagereader/rewards.go
+++ b/internal/storage/storagereader/rewards.go
@@ -13,7 +13,7 @@ import (
 )
 
 // CountRewards returns the number of rewards matching the query.
-func (s *StorageReader) CountRewards(ctx context.Context, query *bson.D, opts ...*options.CountOptions) (int64, error) {
+func (s *Reader) CountRewards(ctx context.Context, query *bson.D, opts ...*options.CountOptions) (int64, error) {
 	count, err := s.db.Collection("rewards").CountDocuments(ctx, query, opts...)
 	if err != nil {
 		return 0, fmt.Errorf("error count transactions: %w", err)
@@ -22,7 +22,7 @@ func (s *StorageReader) CountRewards(ctx context.Context, query *bson.D, opts ..
 }
 
 // GetRewards returns the rewards matching the query.
-func (s *StorageReader) GetRewards(ctx context.Context, query *bson.D, opts ...*options.FindOptions) ([]*model.Reward, error) {
+func (s *Reader) GetRewards(ctx context.Context, query *bson.D, opts ...*options.FindOptions) ([]*model.Reward, error) {
 	cursor, err := s.db.Collection("rewards").Find(ctx, query, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("error get rewards: %w", err)
@@ -36,7 +36,7 @@ func (s *StorageReader) GetRewards(ctx context.Context, query *bson.D, opts ...*
 }
 
 // GetReward returns the reward matching the query.
-func (s *StorageReader) GetReward(ctx context.Context, rewardID string) (*model.Reward, error) {
+func (s *Reader) GetReward(ctx context.Context, rewardID string) (*model.Reward, error) {
 	id, err := primitive.ObjectIDFromHex(strings.ToLower(rewardID))
 	if err != nil {
 		return nil, fmt.Errorf("error create objectID from string `%s`: %w", rewardID, err)

--- a/internal/storage/storagereader/rewards.go
+++ b/internal/storage/storagereader/rewards.go
@@ -1,0 +1,56 @@
+package storagereader
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo/options"
+
+	"github.com/spacemeshos/explorer-backend/model"
+)
+
+// CountRewards returns the number of rewards matching the query.
+func (s *StorageReader) CountRewards(ctx context.Context, query *bson.D, opts ...*options.CountOptions) (int64, error) {
+	count, err := s.db.Collection("rewards").CountDocuments(ctx, query, opts...)
+	if err != nil {
+		return 0, fmt.Errorf("error count transactions: %w", err)
+	}
+	return count, nil
+}
+
+// GetRewards returns the rewards matching the query.
+func (s *StorageReader) GetRewards(ctx context.Context, query *bson.D, opts ...*options.FindOptions) ([]*model.Reward, error) {
+	cursor, err := s.db.Collection("rewards").Find(ctx, query, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("error get rewards: %w", err)
+	}
+
+	var rewards []*model.Reward
+	if err = cursor.All(ctx, &rewards); err != nil {
+		return nil, fmt.Errorf("error decode rewards: %w", err)
+	}
+	return rewards, nil
+}
+
+// GetReward returns the reward matching the query.
+func (s *StorageReader) GetReward(ctx context.Context, rewardID string) (*model.Reward, error) {
+	id, err := primitive.ObjectIDFromHex(strings.ToLower(rewardID))
+	if err != nil {
+		return nil, fmt.Errorf("error create objectID from string `%s`: %w", rewardID, err)
+	}
+	cursor, err := s.db.Collection("rewards").Find(ctx, &bson.D{{"_id", id}})
+	if err != nil {
+		return nil, fmt.Errorf("error get reward `%s`: %w", rewardID, err)
+	}
+	if !cursor.Next(ctx) {
+		return nil, nil
+	}
+	var reward *model.Reward
+	if err = cursor.Decode(&reward); err != nil {
+		return nil, fmt.Errorf("error decode reward `%s`: %w", rewardID, err)
+	}
+	return reward, nil
+}

--- a/internal/storage/storagereader/smeshers.go
+++ b/internal/storage/storagereader/smeshers.go
@@ -1,0 +1,83 @@
+package storagereader
+
+import (
+	"context"
+	"fmt"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+
+	"github.com/spacemeshos/explorer-backend/model"
+	"github.com/spacemeshos/explorer-backend/utils"
+)
+
+// CountSmeshers returns the number of smeshers matching the query.
+func (s *StorageReader) CountSmeshers(ctx context.Context, query *bson.D, opts ...*options.CountOptions) (int64, error) {
+	count, err := s.db.Collection("smeshers").CountDocuments(ctx, query, opts...)
+	if err != nil {
+		return 0, fmt.Errorf("error count transactions: %w", err)
+	}
+	return count, nil
+}
+
+// GetSmeshers returns the smeshers matching the query.
+func (s *StorageReader) GetSmeshers(ctx context.Context, query *bson.D, opts ...*options.FindOptions) ([]*model.Smesher, error) {
+	cursor, err := s.db.Collection("smeshers").Find(ctx, query, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("error get smeshers: %w", err)
+	}
+
+	var txs []*model.Smesher
+	if err = cursor.All(ctx, &txs); err != nil {
+		return nil, fmt.Errorf("error decode smeshers: %w", err)
+	}
+	return txs, nil
+}
+
+// GetSmesher returns the smesher matching the query.
+func (s *StorageReader) GetSmesher(ctx context.Context, smesherID string) (*model.Smesher, error) {
+	cursor, err := s.db.Collection("smeshers").Find(ctx, &bson.D{{"id", smesherID}})
+	if err != nil {
+		return nil, fmt.Errorf("error get smesher `%s`: %w", smesherID, err)
+	}
+	if !cursor.Next(ctx) {
+		return nil, nil
+	}
+	var layer *model.Smesher
+	if err = cursor.Decode(&layer); err != nil {
+		return nil, fmt.Errorf("error decode smesher `%s`: %w", smesherID, err)
+	}
+	return layer, nil
+}
+
+// CountSmesherRewards returns the number of smesher rewards matching the query.
+func (s *StorageReader) CountSmesherRewards(ctx context.Context, smesherID string) (total, count int64, err error) {
+	matchStage := bson.D{{"$match", bson.D{{"smesher", smesherID}}}}
+	groupStage := bson.D{
+		{"$group", bson.D{
+			{"_id", ""},
+			{"total", bson.D{
+				{"$sum", "$total"},
+			}},
+			{"layerReward", bson.D{
+				{"$sum", "$layerReward"},
+			}},
+			{"count", bson.D{
+				{"$sum", 1},
+			}},
+		}},
+	}
+	cursor, err := s.db.Collection("rewards").Aggregate(ctx, mongo.Pipeline{
+		matchStage,
+		groupStage,
+	})
+	if err != nil {
+		return 0, 0, fmt.Errorf("error get smesher rewards: %w", err)
+	}
+	if !cursor.Next(ctx) {
+		return 0, 0, nil
+	}
+	doc := cursor.Current
+	return utils.GetAsInt64(doc.Lookup("total")), utils.GetAsInt64(doc.Lookup("count")), nil
+}

--- a/internal/storage/storagereader/smeshers.go
+++ b/internal/storage/storagereader/smeshers.go
@@ -13,7 +13,7 @@ import (
 )
 
 // CountSmeshers returns the number of smeshers matching the query.
-func (s *StorageReader) CountSmeshers(ctx context.Context, query *bson.D, opts ...*options.CountOptions) (int64, error) {
+func (s *Reader) CountSmeshers(ctx context.Context, query *bson.D, opts ...*options.CountOptions) (int64, error) {
 	count, err := s.db.Collection("smeshers").CountDocuments(ctx, query, opts...)
 	if err != nil {
 		return 0, fmt.Errorf("error count transactions: %w", err)
@@ -22,7 +22,7 @@ func (s *StorageReader) CountSmeshers(ctx context.Context, query *bson.D, opts .
 }
 
 // GetSmeshers returns the smeshers matching the query.
-func (s *StorageReader) GetSmeshers(ctx context.Context, query *bson.D, opts ...*options.FindOptions) ([]*model.Smesher, error) {
+func (s *Reader) GetSmeshers(ctx context.Context, query *bson.D, opts ...*options.FindOptions) ([]*model.Smesher, error) {
 	cursor, err := s.db.Collection("smeshers").Find(ctx, query, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("error get smeshers: %w", err)
@@ -36,7 +36,7 @@ func (s *StorageReader) GetSmeshers(ctx context.Context, query *bson.D, opts ...
 }
 
 // GetSmesher returns the smesher matching the query.
-func (s *StorageReader) GetSmesher(ctx context.Context, smesherID string) (*model.Smesher, error) {
+func (s *Reader) GetSmesher(ctx context.Context, smesherID string) (*model.Smesher, error) {
 	cursor, err := s.db.Collection("smeshers").Find(ctx, &bson.D{{"id", smesherID}})
 	if err != nil {
 		return nil, fmt.Errorf("error get smesher `%s`: %w", smesherID, err)
@@ -52,7 +52,7 @@ func (s *StorageReader) GetSmesher(ctx context.Context, smesherID string) (*mode
 }
 
 // CountSmesherRewards returns the number of smesher rewards matching the query.
-func (s *StorageReader) CountSmesherRewards(ctx context.Context, smesherID string) (total, count int64, err error) {
+func (s *Reader) CountSmesherRewards(ctx context.Context, smesherID string) (total, count int64, err error) {
 	matchStage := bson.D{{"$match", bson.D{{"smesher", smesherID}}}}
 	groupStage := bson.D{
 		{"$group", bson.D{

--- a/internal/storage/storagereader/storage.go
+++ b/internal/storage/storagereader/storage.go
@@ -13,14 +13,14 @@ import (
 	"github.com/spacemeshos/explorer-backend/model"
 )
 
-// StorageReader is a wrapper around a mongo client. This client is read-only.
-type StorageReader struct {
+// Reader is a wrapper around a mongo client. This client is read-only.
+type Reader struct {
 	client *mongo.Client
 	db     *mongo.Database
 }
 
 // NewStorageReader creates a new storage reader.
-func NewStorageReader(ctx context.Context, dbURL string, dbName string) (*StorageReader, error) {
+func NewStorageReader(ctx context.Context, dbURL string, dbName string) (*Reader, error) {
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 	client, err := mongo.Connect(ctx, options.Client().ApplyURI(dbURL))
@@ -31,7 +31,7 @@ func NewStorageReader(ctx context.Context, dbURL string, dbName string) (*Storag
 	if err = client.Ping(ctx, nil); err != nil {
 		return nil, fmt.Errorf("error ping to db: %s", err)
 	}
-	reader := &StorageReader{
+	reader := &Reader{
 		client: client,
 		db:     client.Database(dbName),
 	}
@@ -39,7 +39,7 @@ func NewStorageReader(ctx context.Context, dbURL string, dbName string) (*Storag
 }
 
 // GetNetworkInfo returns the network info matching the query.
-func (s *StorageReader) GetNetworkInfo(ctx context.Context) (*model.NetworkInfo, error) {
+func (s *Reader) GetNetworkInfo(ctx context.Context) (*model.NetworkInfo, error) {
 	cursor, err := s.db.Collection("networkinfo").Find(ctx, bson.D{{"id", 1}})
 	if err != nil {
 		return nil, fmt.Errorf("error get network info: %s", err)
@@ -55,7 +55,7 @@ func (s *StorageReader) GetNetworkInfo(ctx context.Context) (*model.NetworkInfo,
 }
 
 // Ping checks if the database is reachable.
-func (s *StorageReader) Ping(ctx context.Context) error {
+func (s *Reader) Ping(ctx context.Context) error {
 	if s.client == nil {
 		return errors.New("storage not initialized")
 	}

--- a/internal/storage/storagereader/storage.go
+++ b/internal/storage/storagereader/storage.go
@@ -1,0 +1,63 @@
+package storagereader
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+
+	"github.com/spacemeshos/explorer-backend/model"
+)
+
+// StorageReader is a wrapper around a mongo client. This client is read-only.
+type StorageReader struct {
+	client *mongo.Client
+	db     *mongo.Database
+}
+
+// NewStorageReader creates a new storage reader.
+func NewStorageReader(ctx context.Context, dbURL string, dbName string) (*StorageReader, error) {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	client, err := mongo.Connect(ctx, options.Client().ApplyURI(dbURL))
+	if err != nil {
+		return nil, fmt.Errorf("error connect to db: %s", err)
+	}
+
+	if err = client.Ping(ctx, nil); err != nil {
+		return nil, fmt.Errorf("error ping to db: %s", err)
+	}
+	reader := &StorageReader{
+		client: client,
+		db:     client.Database(dbName),
+	}
+	return reader, nil
+}
+
+// GetNetworkInfo returns the network info matching the query.
+func (s *StorageReader) GetNetworkInfo(ctx context.Context) (*model.NetworkInfo, error) {
+	cursor, err := s.db.Collection("networkinfo").Find(ctx, bson.D{{"id", 1}})
+	if err != nil {
+		return nil, fmt.Errorf("error get network info: %s", err)
+	}
+	if !cursor.Next(ctx) {
+		return nil, fmt.Errorf("error get network info: %s", errors.New("empty result"))
+	}
+	var result model.NetworkInfo
+	if err = cursor.Decode(&result); err != nil {
+		return nil, fmt.Errorf("error decode network info: %s", err)
+	}
+	return &result, nil
+}
+
+// Ping checks if the database is reachable.
+func (s *StorageReader) Ping(ctx context.Context) error {
+	if s.client == nil {
+		return errors.New("storage not initialized")
+	}
+	return s.client.Ping(ctx, nil)
+}

--- a/internal/storage/storagereader/transactions.go
+++ b/internal/storage/storagereader/transactions.go
@@ -11,7 +11,7 @@ import (
 )
 
 // CountTransactions returns the number of transactions matching the query.
-func (s *StorageReader) CountTransactions(ctx context.Context, query *bson.D, opts ...*options.CountOptions) (int64, error) {
+func (s *Reader) CountTransactions(ctx context.Context, query *bson.D, opts ...*options.CountOptions) (int64, error) {
 	count, err := s.db.Collection("txs").CountDocuments(ctx, query, opts...)
 	if err != nil {
 		return 0, fmt.Errorf("error count transactions: %w", err)
@@ -20,7 +20,7 @@ func (s *StorageReader) CountTransactions(ctx context.Context, query *bson.D, op
 }
 
 // GetTransactions returns the transactions matching the query.
-func (s *StorageReader) GetTransactions(ctx context.Context, query *bson.D, opts ...*options.FindOptions) ([]*model.Transaction, error) {
+func (s *Reader) GetTransactions(ctx context.Context, query *bson.D, opts ...*options.FindOptions) ([]*model.Transaction, error) {
 	cursor, err := s.db.Collection("txs").Find(ctx, query, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("error get txs: %w", err)

--- a/internal/storage/storagereader/transactions.go
+++ b/internal/storage/storagereader/transactions.go
@@ -1,0 +1,34 @@
+package storagereader
+
+import (
+	"context"
+	"fmt"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo/options"
+
+	"github.com/spacemeshos/explorer-backend/model"
+)
+
+// CountTransactions returns the number of transactions matching the query.
+func (s *StorageReader) CountTransactions(ctx context.Context, query *bson.D, opts ...*options.CountOptions) (int64, error) {
+	count, err := s.db.Collection("txs").CountDocuments(ctx, query, opts...)
+	if err != nil {
+		return 0, fmt.Errorf("error count transactions: %w", err)
+	}
+	return count, nil
+}
+
+// GetTransactions returns the transactions matching the query.
+func (s *StorageReader) GetTransactions(ctx context.Context, query *bson.D, opts ...*options.FindOptions) ([]*model.Transaction, error) {
+	cursor, err := s.db.Collection("txs").Find(ctx, query, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("error get txs: %w", err)
+	}
+
+	var txs []*model.Transaction
+	if err = cursor.All(ctx, &txs); err != nil {
+		return nil, fmt.Errorf("error decode txs: %w", err)
+	}
+	return txs, nil
+}

--- a/model/account.go
+++ b/model/account.go
@@ -1,59 +1,74 @@
 package model
 
 import (
-    "context"
+	"context"
 
-    "go.mongodb.org/mongo-driver/bson"
-    "go.mongodb.org/mongo-driver/mongo/options"
-    pb "github.com/spacemeshos/api/release/go/spacemesh/v1"
-    "github.com/spacemeshos/explorer-backend/utils"
+	pb "github.com/spacemeshos/api/release/go/spacemesh/v1"
+	"github.com/spacemeshos/go-spacemesh/crypto/sha3"
 
-    "github.com/spacemeshos/go-spacemesh/crypto/sha3"
+	"github.com/spacemeshos/explorer-backend/utils"
 )
 
 type Account struct {
-    Address	string	// account public address
-    Balance	uint64	// known account balance
-    Counter	uint64
+	Address string `json:"address" bson:"address"` // account public address
+	Balance uint64 `json:"balance" bson:"balance"` // known account balance
+	Counter uint64 `json:"counter" bson:"counter"`
+	Created uint64 `json:"created" bson:"created"`
+	// get from ledger collection
+	Sent     uint64 `json:"sent" bson:"-"`
+	Received uint64 `json:"received" bson:"-"`
+	Awards   uint64 `json:"awards" bson:"-"`
+	Fees     uint64 `json:"fees" bson:"-"`
+	LayerTms int32  `json:"timestamp" bson:"-"`
+	Txs      int64  `json:"txs" bson:"-"`
+}
+
+// AccountSummary data taken from `ledger` collection. Not all accounts from api have filled this data.
+type AccountSummary struct {
+	Sent     uint64 `json:"sent" bson:"sent"`
+	Received uint64 `json:"received" bson:"received"`
+	Awards   uint64 `json:"awards" bson:"awards"`
+	Fees     uint64 `json:"fees" bson:"fees"`
+	LayerTms int32  `json:"timestamp" bson:"timestamp"`
 }
 
 type AccountService interface {
-    GetAccount(ctx context.Context, query *bson.D) (*Account, error)
-    GetAccounts(ctx context.Context, query *bson.D, opts ...*options.FindOptions) ([]*Account, error)
-    SaveAccount(ctx context.Context, in *Account) error
+	GetAccount(ctx context.Context, accountID string) (*Account, error)
+	GetAccounts(ctx context.Context, page, perPage int64) ([]*Account, int64, error)
+	GetAccountTransactions(ctx context.Context, accountID string, page, perPage int64) ([]*Transaction, int64, error)
+	GetAccountRewards(ctx context.Context, accountID string, page, perPage int64) ([]*Reward, int64, error)
 }
 
 func NewAccount(in *pb.Account) *Account {
-    return &Account{
-        Address: utils.BytesToAddressString(in.GetAccountId().GetAddress()),
-        Balance: in.GetStateCurrent().GetBalance().GetValue(),
-        Counter: in.GetStateCurrent().GetCounter(),
-    }
+	return &Account{
+		Address: utils.BytesToAddressString(in.GetAccountId().GetAddress()),
+		Balance: in.GetStateCurrent().GetBalance().GetValue(),
+		Counter: in.GetStateCurrent().GetCounter(),
+	}
 }
 
 // Hex returns an EIP55-compliant hex string representation of the address.
 func ToCheckedAddress(a string) string {
-    if len(a) != 42 || a[0] != '0' || a[1] != 'x' {
-        return ""
-    }
-    unchecksummed := make([]byte, 40)
-    copy(unchecksummed, a[2:])
-    sha := sha3.NewKeccak256()
-    sha.Write([]byte(unchecksummed))
-    hash := sha.Sum(nil)
+	if len(a) != 42 || a[0] != '0' || a[1] != 'x' {
+		return ""
+	}
+	unchecksummed := make([]byte, 40)
+	copy(unchecksummed, a[2:])
+	sha := sha3.NewKeccak256()
+	sha.Write([]byte(unchecksummed))
+	hash := sha.Sum(nil)
 
-    result := []byte(unchecksummed)
-    for i := 0; i < len(result); i++ {
-        hashByte := hash[i/2]
-        if i%2 == 0 {
-            hashByte = hashByte >> 4
-        } else {
-            hashByte &= 0xf
-        }
-        if result[i] > '9' && hashByte > 7 {
-            result[i] -= 32
-        }
-    }
-    return "0x" + string(result)
+	result := []byte(unchecksummed)
+	for i := 0; i < len(result); i++ {
+		hashByte := hash[i/2]
+		if i%2 == 0 {
+			hashByte = hashByte >> 4
+		} else {
+			hashByte &= 0xf
+		}
+		if result[i] > '9' && hashByte > 7 {
+			result[i] -= 32
+		}
+	}
+	return "0x" + string(result)
 }
-

--- a/model/app.go
+++ b/model/app.go
@@ -1,18 +1,14 @@
 package model
 
 import (
-    "context"
-
-    "go.mongodb.org/mongo-driver/bson"
-    "go.mongodb.org/mongo-driver/mongo/options"
+	"context"
 )
 
 type App struct {
-    Address	string
+	Address string `json:"address" bson:"address"`
 }
 
 type AppService interface {
-    GetAccount(ctx context.Context, query *bson.D) (*App, error)
-    GetApps(ctx context.Context, query *bson.D, opts ...*options.FindOptions) ([]*App, error)
-    SaveApp(ctx context.Context, in *App) error
+	GetApps(ctx context.Context, pageNum, pageSize int64) (apps []*App, total int64, err error)
+	GetApp(ctx context.Context, appID string) (*App, error)
 }

--- a/model/atx.go
+++ b/model/atx.go
@@ -4,26 +4,23 @@ import (
 	"context"
 
 	pb "github.com/spacemeshos/api/release/go/spacemesh/v1"
-	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/mongo/options"
 
 	"github.com/spacemeshos/explorer-backend/utils"
 )
 
 type Activation struct {
-	Id        string //nolint will fix it later.
-	Layer     uint32 // the layer that this activation is part of
-	SmesherId string `json:"smesher"` //nolint will fix it later // id of smesher who created the ATX
-	Coinbase  string // coinbase account id
-	PrevAtx   string // previous ATX pointed to
-	NumUnits  uint32 // number of PoST data commitment units
-	Timestamp uint32
+	Id        string `json:"id" bson:"id"`             //nolint will fix it later.
+	Layer     uint32 `json:"layer" bson:"layer"`       // the layer that this activation is part of
+	SmesherId string `json:"smesher" bson:"smesher"`   //nolint will fix it later // id of smesher who created the ATX
+	Coinbase  string `json:"coinbase" bson:"coinbase"` // coinbase account id
+	PrevAtx   string `json:"prevAtx" bson:"prevAtx"`   // previous ATX pointed to
+	NumUnits  uint32 `json:"numunits" bson:"numunits"` // number of PoST data commitment units
+	Timestamp uint32 `json:"timestamp" bson:"timestamp"`
 }
 
 type ActivationService interface {
-	GetActivation(ctx context.Context, query *bson.D) (*Activation, error)
-	GetActivations(ctx context.Context, query *bson.D, opts ...*options.FindOptions) ([]*Activation, error)
-	SaveActivation(ctx context.Context, in *Activation) error
+	GetActivations(ctx context.Context, page, perPage int64) (atxs []*Activation, total int64, err error)
+	GetActivation(ctx context.Context, activationID string) (*Activation, error)
 }
 
 func NewActivation(atx *pb.Activation, timestamp uint32) *Activation {

--- a/model/block.go
+++ b/model/block.go
@@ -1,24 +1,19 @@
 package model
 
 import (
-    "context"
-
-    "go.mongodb.org/mongo-driver/bson"
-    "go.mongodb.org/mongo-driver/mongo/options"
+	"context"
 )
 
 type Block struct {
-    Id		string
-    Layer	uint32
-    Epoch	uint32
-    Start	uint32
-    End		uint32
-    TxsNumber	uint32
-    TxsValue	uint64
+	Id        string `json:"id" bson:"id"` // nolint will fix it later
+	Layer     uint32 `json:"layer" bson:"layer"`
+	Epoch     uint32 `json:"epoch" bson:"epoch"`
+	Start     uint32 `json:"start" bson:"start"`
+	End       uint32 `json:"end" bson:"end"`
+	TxsNumber uint32 `json:"txsnumber" bson:"txsnumber"`
+	TxsValue  uint64 `json:"txsvalue" bson:"txsvalue"`
 }
 
 type BlockService interface {
-    GetBlock(ctx context.Context, query *bson.D) (*Block, error)
-    GetBlocks(ctx context.Context, query *bson.D, opts ...*options.FindOptions) ([]*Block, error)
-    SaveBlock(ctx context.Context, in *Block) error
+	GetBlock(ctx context.Context, blockID string) (*Block, error)
 }

--- a/model/epoch.go
+++ b/model/epoch.go
@@ -1,42 +1,43 @@
 package model
 
 import (
-    "context"
-
-    "go.mongodb.org/mongo-driver/bson"
-    "go.mongodb.org/mongo-driver/mongo/options"
+	"context"
 )
 
 type Statistics struct {
-    Capacity		int64	// Average tx/s rate over capacity considering all layers in the current epoch.
-    Decentral		int64	// Distribution of storage between all active smeshers.
-    Smeshers		int64	// Number of active smeshers in the current epoch.
-    Transactions	int64	// Total number of transactions processed by the state transition function.
-    Accounts		int64	// Total number of on-mesh accounts with a non-zero coin balance as of the current epoch.
-    Circulation		int64	// Total number of Smesh coins in circulation. This is the total balances of all on-mesh accounts.
-    Rewards		int64	// Total amount of Smesh minted as mining rewards as of the last known reward distribution event.
-    RewardsNumber	int64
-    Security		int64	// Total amount of storage committed to the network based on the ATXs in the previous epoch.
-    TxsAmount		int64	// Total amount of coin transferred between accounts in the epoch. Incl coin transactions and smart wallet transactions.
+	Capacity      int64 `json:"capacity" bson:"capacity"`         // Average tx/s rate over capacity considering all layers in the current epoch.
+	Decentral     int64 `json:"decentral" bson:"decentral"`       // Distribution of storage between all active smeshers.
+	Smeshers      int64 `json:"smeshers" bson:"smeshers"`         // Number of active smeshers in the current epoch.
+	Transactions  int64 `json:"transactions" bson:"transactions"` // Total number of transactions processed by the state transition function.
+	Accounts      int64 `json:"accounts" bson:"accounts"`         // Total number of on-mesh accounts with a non-zero coin balance as of the current epoch.
+	Circulation   int64 `json:"circulation" bson:"circulation"`   // Total number of Smesh coins in circulation. This is the total balances of all on-mesh accounts.
+	Rewards       int64 `json:"rewards" bson:"rewards"`           // Total amount of Smesh minted as mining rewards as of the last known reward distribution event.
+	RewardsNumber int64 `json:"rewardsnumber" bson:"rewardsnumber"`
+	Security      int64 `json:"security" bson:"security"`   // Total amount of storage committed to the network based on the ATXs in the previous epoch.
+	TxsAmount     int64 `json:"txsamount" bson:"txsamount"` // Total amount of coin transferred between accounts in the epoch. Incl coin transactions and smart wallet transactions.
 }
 
 type Stats struct {
-    Current	Statistics
-    Cumulative	Statistics
+	Current    Statistics `json:"current"`
+	Cumulative Statistics `json:"cumulative"`
 }
 
 type Epoch struct {
-    Number	int32
-    Start	uint32
-    End		uint32
-    LayerStart	uint32
-    LayerEnd	uint32
-    Layers	uint32
-    Stats	Stats
+	Number     int32  `json:"number" bson:"number"`
+	Start      uint32 `json:"start" bson:"start"`
+	End        uint32 `json:"end" bson:"end"`
+	LayerStart uint32 `json:"layerstart" bson:"layerstart"`
+	LayerEnd   uint32 `json:"layerend" bson:"layerend"`
+	Layers     uint32 `json:"layers" bson:"layers"`
+	Stats      Stats  `json:"stats"`
 }
 
 type EpochService interface {
-    GetEpoch(ctx context.Context, query *bson.D) (*Epoch, error)
-    GetEpochs(ctx context.Context, query *bson.D, opts ...*options.FindOptions) ([]*Epoch, error)
-    SaveEpoch(ctx context.Context, in *Epoch) error
+	GetEpoch(ctx context.Context, epochNum int) (*Epoch, error)
+	GetEpochs(ctx context.Context, page, perPage int64) (epochs []*Epoch, total int64, err error)
+	GetEpochLayers(ctx context.Context, epochNum int, page, perPage int64) (layers []*Layer, total int64, err error)
+	GetEpochTransactions(ctx context.Context, epochNum int, page, perPage int64) (txs []*Transaction, total int64, err error)
+	GetEpochSmeshers(ctx context.Context, epochNum int, page, perPage int64) (smeshers []*Smesher, total int64, err error)
+	GetEpochRewards(ctx context.Context, epochNum int, page, perPage int64) (rewards []*Reward, total int64, err error)
+	GetEpochActivations(ctx context.Context, epochNum int, page, perPage int64) (atxs []*Activation, total int64, err error)
 }

--- a/model/layer.go
+++ b/model/layer.go
@@ -1,95 +1,99 @@
 package model
 
 import (
-    "context"
+	"context"
 
-    "go.mongodb.org/mongo-driver/bson"
-    "go.mongodb.org/mongo-driver/mongo/options"
-    pb "github.com/spacemeshos/api/release/go/spacemesh/v1"
-    "github.com/spacemeshos/explorer-backend/utils"
+	pb "github.com/spacemeshos/api/release/go/spacemesh/v1"
+
+	"github.com/spacemeshos/explorer-backend/utils"
 )
 
 type Layer struct {
-    Number		uint32
-    Status		int
-    Txs			uint32
-    Start		uint32
-    End			uint32
-    TxsAmount		uint64
-    AtxNumUnits		uint64
-    Rewards		uint64
-    Epoch		uint32
-    Smeshers		uint32
-    Hash		string
-    BlocksNumber	uint32
+	Number       uint32 `json:"number" bson:"number"`
+	Status       int    `json:"status" bson:"status"`
+	Txs          uint32 `json:"txs" bson:"txs"`
+	Start        uint32 `json:"start" bson:"start"`
+	End          uint32 `json:"end" bson:"end"`
+	TxsAmount    uint64 `json:"txsamount" bson:"txsamount"`
+	AtxNumUnits  uint64 `json:"atxnumunits" bson:"atxnumunits"`
+	Rewards      uint64 `json:"rewards" bson:"rewards"`
+	Epoch        uint32 `json:"epoch" bson:"epoch"`
+	Smeshers     uint32 `json:"smeshers" bson:"smeshers"`
+	Hash         string `json:"hash" bson:"hash"`
+	BlocksNumber uint32 `json:"blocksnumber" bson:"blocksnumber"`
 }
 
 type LayerService interface {
-    GetLayer(ctx context.Context, query *bson.D) (*Layer, error)
-    GetLayers(ctx context.Context, query *bson.D, opts ...*options.FindOptions) ([]*Layer, error)
-    SaveLayer(ctx context.Context, in *Layer) error
+	GetLayer(ctx context.Context, layerNum int) (*Layer, error)
+	GetLayerByHash(ctx context.Context, layerHash string) (*Layer, error)
+	GetLayers(ctx context.Context, page, perPage int64) (layers []*Layer, total int64, err error)
+	GetLayerTransactions(ctx context.Context, layerNum int, pageNum, pageSize int64) (txs []*Transaction, total int64, err error)
+	GetLayerSmeshers(ctx context.Context, layerNum int, pageNum, pageSize int64) (smeshers []*Smesher, total int64, err error)
+	GetLayerRewards(ctx context.Context, layerNum int, pageNum, pageSize int64) (rewards []*Reward, total int64, err error)
+	GetLayerActivations(ctx context.Context, layerNum int, pageNum, pageSize int64) (atxs []*Activation, total int64, err error)
+	GetLayerBlocks(ctx context.Context, layerNum int, pageNum, pageSize int64) (blocks []*Block, total int64, err error)
 }
 
 func NewLayer(in *pb.Layer, networkInfo *NetworkInfo) (*Layer, []*Block, []*Activation, map[string]*Transaction) {
-    pbBlocks := in.GetBlocks()
-    pbAtxs := in.GetActivations()
-    layer := &Layer{
-        Number: in.Number.Number,
-        Status: int(in.GetStatus()),
-        Epoch: in.Number.Number / networkInfo.EpochNumLayers,
-        BlocksNumber: uint32(len(pbBlocks)),
-        Hash: utils.BytesToHex(in.Hash),
-    }
-    if layer.Number == 0 {
-        layer.Start = networkInfo.GenesisTime
-    } else {
-        layer.Start = networkInfo.GenesisTime + (layer.Number - 1) * networkInfo.LayerDuration
-    }
-    layer.End = layer.Start + networkInfo.LayerDuration - 1
+	pbBlocks := in.GetBlocks()
+	pbAtxs := in.GetActivations()
+	layer := &Layer{
+		Number:       in.Number.Number,
+		Status:       int(in.GetStatus()),
+		Epoch:        in.Number.Number / networkInfo.EpochNumLayers,
+		BlocksNumber: uint32(len(pbBlocks)),
+		Hash:         utils.BytesToHex(in.Hash),
+	}
+	if layer.Number == 0 {
+		layer.Start = networkInfo.GenesisTime
+	} else {
+		layer.Start = networkInfo.GenesisTime + (layer.Number-1)*networkInfo.LayerDuration
+	}
+	layer.End = layer.Start + networkInfo.LayerDuration - 1
 
-    blocks := make([]*Block, len(pbBlocks))
-    atxs := make([]*Activation, len(pbAtxs))
-    txs := make(map[string]*Transaction)
+	blocks := make([]*Block, len(pbBlocks))
+	atxs := make([]*Activation, len(pbAtxs))
+	txs := make(map[string]*Transaction)
 
-    for i, b := range pbBlocks {
-        blocks[i] = &Block{
-            Id: utils.NBytesToHex(b.GetId(), 20),
-            Layer: layer.Number,
-            Epoch: layer.Epoch,
-            Start: layer.Start,
-            End: layer.End,
-            TxsNumber: uint32(len(b.Transactions)),
-        }
-        for j, t := range b.Transactions {
-            tx := NewTransaction(t, layer.Number, blocks[i].Id, layer.Start, uint32(j))
-            txs[tx.Id] = tx
-            blocks[i].TxsValue += tx.Amount
-        }
-    }
+	for i, b := range pbBlocks {
+		blocks[i] = &Block{
+			Id:        utils.NBytesToHex(b.GetId(), 20),
+			Layer:     layer.Number,
+			Epoch:     layer.Epoch,
+			Start:     layer.Start,
+			End:       layer.End,
+			TxsNumber: uint32(len(b.Transactions)),
+		}
+		for j, t := range b.Transactions {
+			tx := NewTransaction(t, layer.Number, blocks[i].Id, layer.Start, uint32(j))
+			txs[tx.Id] = tx
+			blocks[i].TxsValue += tx.Amount
+		}
+	}
 
-    layer.Txs = uint32(len(txs))
-    for _, tx := range txs {
-        layer.TxsAmount += tx.Amount
-    }
+	layer.Txs = uint32(len(txs))
+	for _, tx := range txs {
+		layer.TxsAmount += tx.Amount
+	}
 
-    smeshers := make(map[string]bool)
-    for i, a := range pbAtxs {
-        atx := NewActivation(a, layer.Start)
-        atx.Layer = layer.Number
-        atxs[i] = atx
-        layer.AtxNumUnits += uint64(atx.NumUnits)
-        smeshers[atx.SmesherId] = true
-    }
+	smeshers := make(map[string]bool)
+	for i, a := range pbAtxs {
+		atx := NewActivation(a, layer.Start)
+		atx.Layer = layer.Number
+		atxs[i] = atx
+		layer.AtxNumUnits += uint64(atx.NumUnits)
+		smeshers[atx.SmesherId] = true
+	}
 
-    layer.Smeshers = uint32(len(smeshers))
+	layer.Smeshers = uint32(len(smeshers))
 
-    return layer, blocks, atxs, txs
+	return layer, blocks, atxs, txs
 }
 
 func IsApprovedLayer(l *pb.Layer) bool {
-    return l.GetStatus() >= pb.Layer_LAYER_STATUS_APPROVED
+	return l.GetStatus() >= pb.Layer_LAYER_STATUS_APPROVED
 }
 
 func IsConfirmedLayer(l *pb.Layer) bool {
-    return l.GetStatus() == pb.Layer_LAYER_STATUS_CONFIRMED
+	return l.GetStatus() == pb.Layer_LAYER_STATUS_CONFIRMED
 }

--- a/model/network_info.go
+++ b/model/network_info.go
@@ -1,20 +1,20 @@
 package model
 
 type NetworkInfo struct {
-    NetId                    uint32
-    GenesisTime              uint32
-    EpochNumLayers           uint32
-    MaxTransactionsPerSecond uint32
-    LayerDuration            uint32
+	NetId                    uint32 `json:"netid" bson:"netid"` // nolint will fix it later
+	GenesisTime              uint32 `json:"genesis" bson:"genesis"`
+	EpochNumLayers           uint32 `json:"layers" bson:"layers"`
+	MaxTransactionsPerSecond uint32 `json:"maxtx" bson:"maxtx"`
+	LayerDuration            uint32 `json:"duration" bson:"duration"`
 
-    LastLayer                uint32
-    LastLayerTimestamp       uint32
-    LastApprovedLayer        uint32
-    LastConfirmedLayer       uint32
+	LastLayer          uint32 `json:"lastlayer" bson:"lastlayer"`
+	LastLayerTimestamp uint32 `json:"lastlayerts" bson:"lastlayerts"`
+	LastApprovedLayer  uint32 `json:"lastapprovedlayer" bson:"lastapprovedlayer"`
+	LastConfirmedLayer uint32 `json:"lastconfirmedlayer" bson:"lastconfirmedlayer"`
 
-    ConnectedPeers           uint64
-    IsSynced                 bool
-    SyncedLayer              uint32
-    TopLayer                 uint32
-    VerifiedLayer            uint32
+	ConnectedPeers uint64 `json:"connectedpeers" bson:"connectedpeers"`
+	IsSynced       bool   `json:"issynced" bson:"issynced"`
+	SyncedLayer    uint32 `json:"syncedlayer" bson:"syncedlayer"`
+	TopLayer       uint32 `json:"toplayer" bson:"toplayer"`
+	VerifiedLayer  uint32 `json:"verifiedlayer" bson:"verifiedlayer"`
 }

--- a/model/reward.go
+++ b/model/reward.go
@@ -1,39 +1,38 @@
 package model
 
 import (
-    "context"
+	"context"
 
-    "go.mongodb.org/mongo-driver/bson"
-    "go.mongodb.org/mongo-driver/mongo/options"
-    pb "github.com/spacemeshos/api/release/go/spacemesh/v1"
-    "github.com/spacemeshos/explorer-backend/utils"
+	pb "github.com/spacemeshos/api/release/go/spacemesh/v1"
+
+	"github.com/spacemeshos/explorer-backend/utils"
 )
 
 type Reward struct {
-    Layer		uint32
-    Total		uint64
-    LayerReward		uint64
-    LayerComputed	uint32	// layer number of the layer when reward was computed
-    // tx_fee = total - layer_reward
-    Coinbase		string	// account awarded this reward
-    Smesher		string	// it will be nice to always have this in reward events
-    Space		uint64
-    Timestamp		uint32
+	ID            string `json:"_id" bson:"_id"`
+	Layer         uint32 `json:"layer" bson:"layer"`
+	Total         uint64 `json:"total" bson:"total"`
+	LayerReward   uint64 `json:"layerReward" bson:"layerReward"`
+	LayerComputed uint32 `json:"layerComputed" bson:"layerComputed"` // layer number of the layer when reward was computed
+	// tx_fee = total - layer_reward
+	Coinbase  string `json:"coinbase" bson:"coinbase"` // account awarded this reward
+	Smesher   string `json:"smesher" bson:"smesher"`   // it will be nice to always have this in reward events
+	Space     uint64 `json:"space" bson:"space"`
+	Timestamp uint32 `json:"timestamp" bson:"timestamp"`
 }
 
 type RewardService interface {
-    GetReward(ctx context.Context, query *bson.D) (*Reward, error)
-    GetRewards(ctx context.Context, query *bson.D, opts ...*options.FindOptions) ([]*Reward, error)
-    SaveReward(ctx context.Context, in *Reward) error
+	GetReward(ctx context.Context, rewardID string) (*Reward, error)
+	GetRewards(ctx context.Context, page, perPage int64) ([]*Reward, int64, error)
 }
 
 func NewReward(reward *pb.Reward) *Reward {
-    return &Reward{
-        Layer: reward.GetLayer().GetNumber(),
-        Total: reward.GetTotal().GetValue(),
-        LayerReward: reward.GetLayerReward().GetValue(),
-        LayerComputed: reward.GetLayerComputed().GetNumber(),
-        Coinbase: utils.BytesToAddressString(reward.GetCoinbase().GetAddress()),
-        Smesher: utils.BytesToHex(reward.GetSmesher().GetId()),
-    }
+	return &Reward{
+		Layer:         reward.GetLayer().GetNumber(),
+		Total:         reward.GetTotal().GetValue(),
+		LayerReward:   reward.GetLayerReward().GetValue(),
+		LayerComputed: reward.GetLayerComputed().GetNumber(),
+		Coinbase:      utils.BytesToAddressString(reward.GetCoinbase().GetAddress()),
+		Smesher:       utils.BytesToHex(reward.GetSmesher().GetId()),
+	}
 }

--- a/model/smesher.go
+++ b/model/smesher.go
@@ -1,28 +1,30 @@
 package model
 
 import (
-    "context"
-
-    "go.mongodb.org/mongo-driver/bson"
-    "go.mongodb.org/mongo-driver/mongo/options"
+	"context"
 )
 
 type Geo struct {
-    Name	string `json:"name"`
-    Coordinates	[2]float64 `json:"coordinates"`
+	Name        string     `json:"name"`
+	Coordinates [2]float64 `json:"coordinates"`
 }
 
 type Smesher struct {
-	Id             string //nolint will fix it later.
-	Geo            Geo
-	CommitmentSize uint64 `json:"cSize"`
-	Coinbase       string
-	AtxCount       uint32
-	Timestamp      uint32
+	Id             string  `json:"id" bson:"id"` //nolint will fix it later.
+	CommitmentSize uint64  `json:"cSize" bson:"cSize"`
+	Coinbase       string  `json:"coinbase" bson:"coinbase"`
+	AtxCount       uint32  `json:"atxcount" bson:"atxcount"`
+	Timestamp      uint32  `json:"timestamp" bson:"timestamp"`
+	Name           string  `json:"name" bson:"name"`
+	Lat            float64 `json:"lat" bson:"lat"`
+	Lon            float64 `json:"lon" bson:"lon"`
+	Rewards        int64   `json:"rewards" bson:"-"`
 }
 
 type SmesherService interface {
-    GetSmesher(ctx context.Context, query *bson.D) (*Smesher, error)
-    GetSmeshers(ctx context.Context, query *bson.D, opts ...*options.FindOptions) ([]*Smesher, error)
-    SaveSmesher(ctx context.Context, in *Smesher) error
+	GetSmesher(ctx context.Context, smesherID string) (*Smesher, error)
+	GetSmeshers(ctx context.Context, page, perPage int64) (smeshers []*Smesher, total int64, err error)
+	GetSmesherActivations(ctx context.Context, smesherID string, page, perPage int64) (atxs []*Activation, total int64, err error)
+	GetSmesherRewards(ctx context.Context, smesherID string, page, perPage int64) (rewards []*Reward, total int64, err error)
+	CountSmesherRewards(ctx context.Context, smesherID string) (total, count int64, err error)
 }

--- a/model/tx.go
+++ b/model/tx.go
@@ -4,38 +4,36 @@ import (
 	"context"
 
 	pb "github.com/spacemeshos/api/release/go/spacemesh/v1"
-	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/mongo/options"
 
 	"github.com/spacemeshos/explorer-backend/utils"
 )
 
 type Transaction struct {
-	Id string //nolint will fix it later
+	Id string `json:"id" bson:"id"` //nolint will fix it later
 
-	Layer      uint32
-	Block      string
-	BlockIndex uint32
-	Index      uint32 // the index of the tx in the ordered list of txs to be executed by stf in the layer
-	State      int
-	Timestamp  uint32
+	Layer      uint32 `json:"layer" bson:"layer"`
+	Block      string `json:"block" bson:"block"`
+	BlockIndex uint32 `json:"blockIndex" bson:"blockIndex"`
+	Index      uint32 `json:"index" bson:"index"` // the index of the tx in the ordered list of txs to be executed by stf in the layer
+	State      int    `json:"state" bson:"state"`
+	Timestamp  uint32 `json:"timestamp" bson:"timestamp"`
 
-	GasProvided uint64
-	GasPrice    uint64
-	GasUsed     uint64 // gas units used by the transaction (gas price in tx)
-	Fee         uint64 // transaction fee charged for the transaction
+	GasProvided uint64 `json:"gasProvided" bson:"gasProvided"`
+	GasPrice    uint64 `json:"gasPrice" bson:"gasPrice"`
+	GasUsed     uint64 `bson:"gasUsed"`        // gas units used by the transaction (gas price in tx)
+	Fee         uint64 `json:"fee" bson:"fee"` // transaction fee charged for the transaction
 
-	Amount  uint64 // amount of coin transferred in this tx by sender
-	Counter uint64 // tx counter aka nonce
+	Amount  uint64 `json:"amount" bson:"amount"`   // amount of coin transferred in this tx by sender
+	Counter uint64 `json:"counter" bson:"counter"` // tx counter aka nonce
 
-	Type      int
-	Scheme    int    // the signature's scheme
-	Signature string // the signature itself
-	PublicKey string `json:"pubKey"` // included in schemes which require signer to provide a public key
+	Type      int    `json:"type" bson:"type"`
+	Scheme    int    `json:"scheme" bson:"scheme"`       // the signature's scheme
+	Signature string `json:"signature" bson:"signature"` // the signature itself
+	PublicKey string `json:"pubKey" bson:"pubKey"`       // included in schemes which require signer to provide a public key
 
-	Sender   string // tx originator, should match signer inside Signature
-	Receiver string
-	SvmData  string // svm binary data. Decode with svm-codec
+	Sender   string `json:"sender" bson:"sender"` // tx originator, should match signer inside Signature
+	Receiver string `json:"receiver" bson:"receiver"`
+	SvmData  string `json:"svmData" bson:"svmData"` // svm binary data. Decode with svm-codec
 }
 
 type TransactionReceipt struct {
@@ -49,9 +47,8 @@ type TransactionReceipt struct {
 }
 
 type TransactionService interface {
-	GetTransaction(ctx context.Context, query *bson.D) (*Transaction, error)
-	GetTransactions(ctx context.Context, query *bson.D, opts ...*options.FindOptions) ([]*Transaction, error)
-	SaveTransaction(ctx context.Context, in *Transaction) error
+	GetTransaction(ctx context.Context, txID string) (*Transaction, error)
+	GetTransactions(ctx context.Context, page, perPage int64) (txs []*Transaction, total int64, err error)
 }
 
 func NewTransactionReceipt(txReceipt *pb.TransactionReceipt) *TransactionReceipt {

--- a/storage/smesher.go
+++ b/storage/smesher.go
@@ -1,159 +1,164 @@
 package storage
 
 import (
-    "context"
-    "errors"
-    "time"
+	"context"
+	"errors"
+	"fmt"
+	"time"
 
-    "go.mongodb.org/mongo-driver/bson"
-    "go.mongodb.org/mongo-driver/mongo"
-    "go.mongodb.org/mongo-driver/mongo/options"
+	"github.com/spacemeshos/go-spacemesh/log"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
 
-    "github.com/spacemeshos/go-spacemesh/log"
-
-    "github.com/spacemeshos/explorer-backend/model"
-    "github.com/spacemeshos/explorer-backend/utils"
+	"github.com/spacemeshos/explorer-backend/model"
+	"github.com/spacemeshos/explorer-backend/utils"
 )
 
 func (s *Storage) InitSmeshersStorage(ctx context.Context) error {
-    _, err := s.db.Collection("smeshers").Indexes().CreateOne(ctx, mongo.IndexModel{Keys: bson.D{{"id", 1}}, Options: options.Index().SetName("idIndex").SetUnique(true)});
-    _, err = s.db.Collection("coinbases").Indexes().CreateOne(ctx, mongo.IndexModel{Keys: bson.D{{"address", 1}}, Options: options.Index().SetName("addressIndex").SetUnique(true)});
-    return err
+	_, err := s.db.Collection("smeshers").Indexes().CreateOne(ctx, mongo.IndexModel{Keys: bson.D{{"id", 1}}, Options: options.Index().SetName("idIndex").SetUnique(true)})
+	if err != nil {
+		return fmt.Errorf("error init `smeshers` collection: %w", err)
+	}
+	_, err = s.db.Collection("coinbases").Indexes().CreateOne(ctx, mongo.IndexModel{Keys: bson.D{{"address", 1}}, Options: options.Index().SetName("addressIndex").SetUnique(true)})
+	if err != nil {
+		return fmt.Errorf("error init `coinbases` collection: %w", err)
+	}
+	return nil
 }
 
 func (s *Storage) GetSmesher(parent context.Context, query *bson.D) (*model.Smesher, error) {
-    ctx, cancel := context.WithTimeout(parent, 5*time.Second)
-    defer cancel()
-    cursor, err := s.db.Collection("smeshers").Find(ctx, query)
-    if err != nil {
-        log.Info("GetSmesher: %v", err)
-        return nil, err
-    }
-    if !cursor.Next(ctx) {
-        log.Info("GetSmesher: Empty result")
-        return nil, errors.New("Empty result")
-    }
-    doc := cursor.Current
-    smesher := &model.Smesher{
-        Id: utils.GetAsString(doc.Lookup("id")),
-        Geo: model.Geo{
-            utils.GetAsString(doc.Lookup("name")),
-            [2]float64 { doc.Lookup("lon").Double(), doc.Lookup("lat").Double() },
-        },
-        CommitmentSize: utils.GetAsUInt64(doc.Lookup("cSize")),
-        Coinbase: utils.GetAsString(doc.Lookup("coinbase")),
-        AtxCount: utils.GetAsUInt32(doc.Lookup("atxcount")),
-        Timestamp: utils.GetAsUInt32(doc.Lookup("timestamp")),
-    }
-    return smesher, nil
+	ctx, cancel := context.WithTimeout(parent, 5*time.Second)
+	defer cancel()
+	cursor, err := s.db.Collection("smeshers").Find(ctx, query)
+	if err != nil {
+		log.Info("GetSmesher: %v", err)
+		return nil, err
+	}
+	if !cursor.Next(ctx) {
+		log.Info("GetSmesher: Empty result")
+		return nil, errors.New("Empty result")
+	}
+	doc := cursor.Current
+	smesher := &model.Smesher{
+		Id:             utils.GetAsString(doc.Lookup("id")),
+		Name:           utils.GetAsString(doc.Lookup("name")),
+		Lon:            doc.Lookup("lon").Double(),
+		Lat:            doc.Lookup("lat").Double(),
+		CommitmentSize: utils.GetAsUInt64(doc.Lookup("cSize")),
+		Coinbase:       utils.GetAsString(doc.Lookup("coinbase")),
+		AtxCount:       utils.GetAsUInt32(doc.Lookup("atxcount")),
+		Timestamp:      utils.GetAsUInt32(doc.Lookup("timestamp")),
+	}
+	return smesher, nil
 }
 
 func (s *Storage) GetSmesherByCoinbase(parent context.Context, coinbase string) (*model.Smesher, error) {
-    ctx, cancel := context.WithTimeout(parent, 5*time.Second)
-    defer cancel()
-    cursor, err := s.db.Collection("coinbases").Find(ctx, &bson.D{{"address", coinbase}})
-    if err != nil {
-        log.Info("GetSmesherByCoinbase: %v", err)
-        return nil, err
-    }
-    if !cursor.Next(ctx) {
-        log.Info("GetSmesherByCoinbase: Empty result")
-        return nil, errors.New("Empty result")
-    }
-    doc := cursor.Current
-    smesher := utils.GetAsString(doc.Lookup("smesher"))
-    if smesher == "" {
-        log.Info("GetSmesherByCoinbase: Empty result")
-        return nil, errors.New("Empty result")
-    }
-    return s.GetSmesher(ctx, &bson.D{{"id", smesher}})
+	ctx, cancel := context.WithTimeout(parent, 5*time.Second)
+	defer cancel()
+	cursor, err := s.db.Collection("coinbases").Find(ctx, &bson.D{{"address", coinbase}})
+	if err != nil {
+		log.Info("GetSmesherByCoinbase: %v", err)
+		return nil, err
+	}
+	if !cursor.Next(ctx) {
+		log.Info("GetSmesherByCoinbase: Empty result")
+		return nil, errors.New("Empty result")
+	}
+	doc := cursor.Current
+	smesher := utils.GetAsString(doc.Lookup("smesher"))
+	if smesher == "" {
+		log.Info("GetSmesherByCoinbase: Empty result")
+		return nil, errors.New("Empty result")
+	}
+	return s.GetSmesher(ctx, &bson.D{{"id", smesher}})
 }
 
 func (s *Storage) GetSmeshersCount(parent context.Context, query *bson.D, opts ...*options.CountOptions) int64 {
-    ctx, cancel := context.WithTimeout(parent, 5*time.Second)
-    defer cancel()
-    count, err := s.db.Collection("smeshers").CountDocuments(ctx, query, opts...)
-    if err != nil {
-        log.Info("GetSmeshersCount: %v", err)
-        return 0
-    }
-    return count
+	ctx, cancel := context.WithTimeout(parent, 5*time.Second)
+	defer cancel()
+	count, err := s.db.Collection("smeshers").CountDocuments(ctx, query, opts...)
+	if err != nil {
+		log.Info("GetSmeshersCount: %v", err)
+		return 0
+	}
+	return count
 }
 
 func (s *Storage) IsSmesherExists(parent context.Context, smesher string) bool {
-    ctx, cancel := context.WithTimeout(parent, 5*time.Second)
-    defer cancel()
-    count, err := s.db.Collection("smeshers").CountDocuments(ctx, bson.D{{"id", smesher}})
-    if err != nil {
-        log.Info("IsSmesherExists: %v", err)
-        return false
-    }
-    return count > 0
+	ctx, cancel := context.WithTimeout(parent, 5*time.Second)
+	defer cancel()
+	count, err := s.db.Collection("smeshers").CountDocuments(ctx, bson.D{{"id", smesher}})
+	if err != nil {
+		log.Info("IsSmesherExists: %v", err)
+		return false
+	}
+	return count > 0
 }
 
 func (s *Storage) GetSmeshers(parent context.Context, query *bson.D, opts ...*options.FindOptions) ([]bson.D, error) {
-    ctx, cancel := context.WithTimeout(parent, 5*time.Second)
-    defer cancel()
-    cursor, err := s.db.Collection("smeshers").Find(ctx, query, opts...)
-    if err != nil {
-        log.Info("GetSmeshers: %v", err)
-        return nil, err
-    }
-    var docs interface{} = []bson.D{}
-    err = cursor.All(ctx, &docs)
-    if err != nil {
-        log.Info("GetSmeshers: %v", err)
-        return nil, err
-    }
-    if len(docs.([]bson.D)) == 0 {
-        return nil, nil
-    }
-    return docs.([]bson.D), nil
+	ctx, cancel := context.WithTimeout(parent, 5*time.Second)
+	defer cancel()
+	cursor, err := s.db.Collection("smeshers").Find(ctx, query, opts...)
+	if err != nil {
+		log.Info("GetSmeshers: %v", err)
+		return nil, err
+	}
+	var docs interface{} = []bson.D{}
+	err = cursor.All(ctx, &docs)
+	if err != nil {
+		log.Info("GetSmeshers: %v", err)
+		return nil, err
+	}
+	if len(docs.([]bson.D)) == 0 {
+		return nil, nil
+	}
+	return docs.([]bson.D), nil
 }
 
 func (s *Storage) SaveSmesher(parent context.Context, in *model.Smesher) error {
-    ctx, cancel := context.WithTimeout(parent, 5*time.Second)
-    defer cancel()
-    _, err := s.db.Collection("smeshers").InsertOne(ctx, bson.D{
-        {"id", in.Id},
-        {"name", in.Geo.Name},
-        {"lon", in.Geo.Coordinates[0]},
-        {"lat", in.Geo.Coordinates[1]},
-        {"cSize", in.CommitmentSize},
-        {"coinbase", in.Coinbase},
-        {"atxcount", in.AtxCount},
-        {"timestamp", in.Timestamp},
-    })
-    if err != nil {
-//        log.Info("SaveSmesher: %v", err)
-    }
-    return err
+	ctx, cancel := context.WithTimeout(parent, 5*time.Second)
+	defer cancel()
+	_, err := s.db.Collection("smeshers").InsertOne(ctx, bson.D{
+		{"id", in.Id},
+		{"name", in.Name},
+		{"lon", in.Lon},
+		{"lat", in.Lat},
+		{"cSize", in.CommitmentSize},
+		{"coinbase", in.Coinbase},
+		{"atxcount", in.AtxCount},
+		{"timestamp", in.Timestamp},
+	})
+	if err != nil {
+		return fmt.Errorf("error save smesher: %w", err)
+	}
+	return nil
 }
 
 func (s *Storage) UpdateSmesher(parent context.Context, smesher string, coinbase string, space uint64, timestamp uint32) error {
-    ctx, cancel := context.WithTimeout(parent, 5*time.Second)
-    defer cancel()
-    _, err := s.db.Collection("coinbases").InsertOne(ctx, bson.D{
-        {"address", coinbase},
-        {"smesher", smesher},
-    })
-    if err != nil {
-//        log.Info("UpdateSmesher: coinbase: %v", err)
-    }
-    atxCount, err := s.db.Collection("activations").CountDocuments(ctx, &bson.D{{"smesher", smesher}})
-    if err != nil {
-        log.Info("UpdateSmesher: GetActivationsCount: %v", err)
-    }
-    _, err = s.db.Collection("smeshers").UpdateOne(ctx, bson.D{{"id", smesher}}, bson.D{
-        {"$set", bson.D{
-            {"cSize", space},
-            {"coinbase", coinbase},
-            {"atxcount", atxCount},
-            {"timestamp", timestamp},
-        }},
-    })
-    if err != nil {
-        log.Info("UpdateSmesher: %v", err)
-    }
-    return err
+	ctx, cancel := context.WithTimeout(parent, 5*time.Second)
+	defer cancel()
+	_, err := s.db.Collection("coinbases").InsertOne(ctx, bson.D{
+		{"address", coinbase},
+		{"smesher", smesher},
+	})
+	if err != nil {
+		return fmt.Errorf("error insert smesher into `coinbases`: %w", err)
+	}
+	atxCount, err := s.db.Collection("activations").CountDocuments(ctx, &bson.D{{"smesher", smesher}})
+	if err != nil {
+		log.Info("UpdateSmesher: GetActivationsCount: %v", err)
+	}
+	_, err = s.db.Collection("smeshers").UpdateOne(ctx, bson.D{{"id", smesher}}, bson.D{
+		{"$set", bson.D{
+			{"cSize", space},
+			{"coinbase", coinbase},
+			{"atxcount", atxCount},
+			{"timestamp", timestamp},
+		}},
+	})
+	if err != nil {
+		log.Info("UpdateSmesher: %v", err)
+	}
+	return err
 }

--- a/testhelpers/testseed/account.go
+++ b/testhelpers/testseed/account.go
@@ -17,6 +17,18 @@ type AccountContainer struct {
 func (s *SeedGenerator) saveTransactionForAccount(tx *model.Transaction, accountFrom, accountTo string) {
 	s.Accounts[strings.ToLower(accountFrom)].Transactions[tx.Id] = tx
 	s.Accounts[strings.ToLower(accountTo)].Transactions[tx.Id] = tx
+
+	tmpContainerFrom := s.Accounts[strings.ToLower(accountFrom)]
+	tmpContainerFrom.Account.Txs++
+	s.Accounts[strings.ToLower(accountFrom)] = tmpContainerFrom
+
+	if accountTo == accountFrom {
+		return
+	}
+
+	tmpContainerTo := s.Accounts[strings.ToLower(accountTo)]
+	tmpContainerTo.Account.Txs++
+	s.Accounts[strings.ToLower(accountTo)] = tmpContainerTo
 }
 
 func (s *SeedGenerator) saveReward(reward *model.Reward) {

--- a/testhelpers/testseed/epoch.go
+++ b/testhelpers/testseed/epoch.go
@@ -12,6 +12,7 @@ type TestServerSeed struct {
 	EpochNumLayers          uint64
 	LayersDuration          uint64
 	MaxTransactionPerSecond uint64
+	GenesisTime             uint64
 
 	BitsPerLabel  uint32
 	LabelsPerUnit uint64
@@ -27,6 +28,7 @@ func (t *TestServerSeed) GetPostUnitsSize() uint64 {
 // GetServerSeed generate test network config.
 func GetServerSeed() *TestServerSeed {
 	return &TestServerSeed{
+		GenesisTime:             1234567,
 		NetID:                   123,
 		EpochNumLayers:          10,
 		LayersDuration:          10,

--- a/testhelpers/testseed/generator.go
+++ b/testhelpers/testseed/generator.go
@@ -168,7 +168,7 @@ func (s *SeedGenerator) fillLayer(layerID, epochID int32, seedEpoch *SeedEpoch) 
 	seedEpoch.Layers = append(seedEpoch.Layers, layerContainer)
 
 	for k := 0; k <= rand.Intn(3); k++ {
-		tmpAcc := generateAccount()
+		tmpAcc := s.generateAccount(tmpLayer.Number)
 		s.Accounts[strings.ToLower(tmpAcc.Address)] = AccountContainer{
 			layerID:      uint32(layerID),
 			Account:      tmpAcc,
@@ -231,6 +231,7 @@ func (s *SeedGenerator) fillLayer(layerID, epochID int32, seedEpoch *SeedEpoch) 
 		seedEpoch.Blocks[tmpBl.Id] = &tmpBl
 		s.Rewards[strings.ToLower(tmpRw.Smesher)] = &tmpRw
 		s.Smeshers[strings.ToLower(tmpSm.Id)] = &tmpSm
+		s.Smeshers[strings.ToLower(tmpSm.Id)].Rewards = int64(tmpRw.Total)
 		seedEpoch.Epoch.Stats.Current.RewardsNumber++
 		seedEpoch.Epoch.Stats.Current.Rewards += int64(tmpRw.Total)
 		seedEpoch.Epoch.Stats.Current.Capacity += int64(tmpSm.CommitmentSize)
@@ -382,11 +383,13 @@ func (s *SeedGenerator) generateBlocks(layerNum, epochNum int32) model.Block {
 	}
 }
 
-func generateAccount() model.Account {
+func (s *SeedGenerator) generateAccount(layerNum uint32) model.Account {
 	return model.Account{
-		Address: utils.BytesToAddressString(randomBytes(20)),
-		Balance: 0,
-		Counter: 0,
+		Address:  utils.BytesToAddressString(randomBytes(20)),
+		Balance:  0,
+		Counter:  0,
+		Created:  uint64(layerNum),
+		LayerTms: int32(s.seed.GenesisTime),
 	}
 }
 

--- a/testhelpers/testserver/test_api.go
+++ b/testhelpers/testserver/test_api.go
@@ -55,7 +55,7 @@ func StartTestAPIService(dbPort int, db *storage.Storage) (*TestAPIService, erro
 }
 
 // StartTestAPIServiceV2 start test api service with refacored router.
-func StartTestAPIServiceV2(db *storage.Storage, dbReader *storagereader.StorageReader) (*TestAPIService, error) {
+func StartTestAPIServiceV2(db *storage.Storage, dbReader *storagereader.Reader) (*TestAPIService, error) {
 	appPort, err := freeport.GetFreePort()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get free port: %s", err)

--- a/testhelpers/testserver/test_api.go
+++ b/testhelpers/testserver/test_api.go
@@ -13,6 +13,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/spacemeshos/explorer-backend/api"
+	"github.com/spacemeshos/explorer-backend/internal/router"
+	service2 "github.com/spacemeshos/explorer-backend/internal/service"
+	"github.com/spacemeshos/explorer-backend/internal/storage/storagereader"
 	"github.com/spacemeshos/explorer-backend/storage"
 	"github.com/spacemeshos/explorer-backend/testhelpers/testutils"
 )
@@ -29,7 +32,7 @@ type TestAPIService struct {
 }
 
 // StartTestAPIService start test api service.
-func StartTestAPIService(dbPort int) (*TestAPIService, error) {
+func StartTestAPIService(dbPort int, db *storage.Storage) (*TestAPIService, error) {
 	appPort, err := freeport.GetFreePort()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get free port: %s", err)
@@ -45,8 +48,28 @@ func StartTestAPIService(dbPort int) (*TestAPIService, error) {
 	}
 	go server.Run()
 	return &TestAPIService{
-		server: server,
-		port:   appPort,
+		server:  server,
+		port:    appPort,
+		Storage: db,
+	}, nil
+}
+
+// StartTestAPIServiceV2 start test api service with refacored router.
+func StartTestAPIServiceV2(db *storage.Storage, dbReader *storagereader.StorageReader) (*TestAPIService, error) {
+	appPort, err := freeport.GetFreePort()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get free port: %s", err)
+	}
+	println("starting test api service on port", appPort)
+
+	appV2 := router.InitAppRouter(&router.Config{
+		ListenOn: fmt.Sprintf(":%d", appPort),
+	}, service2.NewService(dbReader, time.Second))
+	go appV2.Run()
+
+	return &TestAPIService{
+		Storage: db,
+		port:    appPort,
 	}, nil
 }
 

--- a/tests/api/accounts_test.go
+++ b/tests/api/accounts_test.go
@@ -17,6 +17,9 @@ func TestAccounts(t *testing.T) { // accounts
 	for _, acc := range resp.Data {
 		accGenerated, ok := generator.Accounts[strings.ToLower(acc.Address)]
 		require.True(t, ok)
+		// this not calculated on list endpoints
+		acc.LayerTms = accGenerated.Account.LayerTms
+		acc.Txs = accGenerated.Account.Txs
 		require.Equal(t, accGenerated.Account, acc)
 	}
 }

--- a/tests/api/atxs_test.go
+++ b/tests/api/atxs_test.go
@@ -24,17 +24,19 @@ func TestActivations(t *testing.T) { // /atxs
 func TestActivation(t *testing.T) { // /atxs/{id}
 	t.Parallel()
 	insertedAtxs := generator.Epochs.GetActivations()
-	res := apiServer.Get(t, apiPrefix+"/atxs?pagesize=100")
+	res := apiServer.Get(t, apiPrefix+"/atxs?pagesize=1000")
 	res.RequireOK(t)
 	var resp atxResp
+	res.RequireUnmarshal(t, &resp)
+	require.Equal(t, len(insertedAtxs), len(resp.Data))
 	for _, atx := range resp.Data {
 		response := apiServer.Get(t, apiPrefix+"/atxs/"+atx.Id)
 		response.RequireOK(t)
-		var respLoop rewardResp
+		var respLoop atxResp
 		response.RequireUnmarshal(t, &respLoop)
 		require.Equal(t, 1, len(respLoop.Data))
 		generatedAtx, ok := insertedAtxs[atx.Id]
 		require.True(t, ok)
-		require.Equal(t, generatedAtx, respLoop.Data[0])
+		require.Equal(t, *generatedAtx, respLoop.Data[0])
 	}
 }

--- a/tests/api/epochs_test.go
+++ b/tests/api/epochs_test.go
@@ -95,10 +95,11 @@ func TestEpochSmeshersHandler(t *testing.T) {
 		var loopResult smesherResp
 		res.RequireUnmarshal(t, &loopResult)
 		require.Equal(t, len(ep.Smeshers), len(loopResult.Data))
-		for _, tx := range loopResult.Data {
-			generatedSmesher, ok := ep.Smeshers[strings.ToLower(tx.Id)]
+		for _, smesher := range loopResult.Data {
+			generatedSmesher, ok := ep.Smeshers[strings.ToLower(smesher.Id)]
 			require.True(t, ok)
-			require.Equal(t, *generatedSmesher, tx)
+			smesher.Rewards = generatedSmesher.Rewards // this not calculated on list endpoints, simply set as 0.
+			require.Equal(t, *generatedSmesher, smesher)
 		}
 	}
 }

--- a/tests/api/layers_test.go
+++ b/tests/api/layers_test.go
@@ -71,6 +71,7 @@ func TestLayerSmeshers(t *testing.T) { // /layers/{id:[0-9]+}/smeshers
 			for _, smesher := range loopResp.Data {
 				generatedSmesher, ok := epoch.Smeshers[strings.ToLower(smesher.Id)]
 				require.True(t, ok)
+				smesher.Rewards = generatedSmesher.Rewards // this not calculated on list endpoints, simply set as 0.
 				require.Equal(t, *generatedSmesher, smesher)
 			}
 		}

--- a/tests/api/network_info_test.go
+++ b/tests/api/network_info_test.go
@@ -1,7 +1,9 @@
 package api
 
 import (
+	"net/http"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -11,20 +13,20 @@ const apiPrefix = "" // will be replaced to v2 after some endpoints will be refa
 func TestNetworkInfoHandler(t *testing.T) {
 	type resp struct {
 		Network struct {
-			Netid              int  `json:"netid"`
-			Genesis            int  `json:"genesis"`
-			Layers             int  `json:"layers"`
-			Maxtx              int  `json:"maxtx"`
-			Duration           int  `json:"duration"`
-			Lastlayer          int  `json:"lastlayer"`
-			Lastlayerts        int  `json:"lastlayerts"`
-			Lastapprovedlayer  int  `json:"lastapprovedlayer"`
-			Lastconfirmedlayer int  `json:"lastconfirmedlayer"`
-			Connectedpeers     int  `json:"connectedpeers"`
-			Issynced           bool `json:"issynced"`
-			Syncedlayer        int  `json:"syncedlayer"`
-			Toplayer           int  `json:"toplayer"`
-			Verifiedlayer      int  `json:"verifiedlayer"`
+			Netid              uint64 `json:"netid"`
+			Genesis            uint64 `json:"genesis"`
+			Layers             uint64 `json:"layers"`
+			Maxtx              uint64 `json:"maxtx"`
+			Duration           uint64 `json:"duration"`
+			Lastlayer          int    `json:"lastlayer"`
+			Lastlayerts        int    `json:"lastlayerts"`
+			Lastapprovedlayer  int    `json:"lastapprovedlayer"`
+			Lastconfirmedlayer int    `json:"lastconfirmedlayer"`
+			Connectedpeers     int    `json:"connectedpeers"`
+			Issynced           bool   `json:"issynced"`
+			Syncedlayer        int    `json:"syncedlayer"`
+			Toplayer           int    `json:"toplayer"`
+			Verifiedlayer      int    `json:"verifiedlayer"`
 		} `json:"network"`
 	}
 
@@ -32,17 +34,19 @@ func TestNetworkInfoHandler(t *testing.T) {
 	var networkInfo resp
 	res.RequireOK(t)
 	res.RequireUnmarshal(t, &networkInfo)
-	require.Equal(t, 123, networkInfo.Network.Netid)
-	require.Equal(t, 2, networkInfo.Network.Genesis)
-	require.Equal(t, 10, networkInfo.Network.Layers)
-	require.Equal(t, 100, networkInfo.Network.Maxtx)
-	require.Equal(t, 10, networkInfo.Network.Duration)
+	require.Equal(t, seed.NetID, networkInfo.Network.Netid)
+	require.Equal(t, seed.GenesisTime, networkInfo.Network.Genesis)
+	require.Equal(t, seed.EpochNumLayers, networkInfo.Network.Layers)
+	require.Equal(t, seed.MaxTransactionPerSecond, networkInfo.Network.Maxtx)
+	require.Equal(t, seed.LayersDuration, networkInfo.Network.Duration)
 }
 
 func TestSyncedHandler(t *testing.T) {
 	res := apiServer.Get(t, apiPrefix+"/synced")
 	res.RequireTooEarly(t)
 	apiServer.Storage.OnNodeStatus(10, true, 11, 12, 13)
-	res = apiServer.Get(t, apiPrefix+"/synced")
-	res.RequireOK(t)
+	require.Eventually(t, func() bool {
+		res = apiServer.Get(t, apiPrefix+"/synced")
+		return res.Res.StatusCode == http.StatusOK
+	}, 4*time.Second, 1*time.Second)
 }

--- a/tests/api/rewards_test.go
+++ b/tests/api/rewards_test.go
@@ -17,6 +17,7 @@ func TestRewards(t *testing.T) { //"/rewards"
 	for _, reward := range resp.Data {
 		rw, ok := insertedRewards[reward.Smesher]
 		require.True(t, ok)
+		reward.ID = ""
 		require.Equal(t, rw, &reward)
 	}
 }
@@ -44,13 +45,15 @@ func TestReward(t *testing.T) { //"/rewards/{id}"
 	var resp rewardRespWithID
 	res.RequireUnmarshal(t, &resp)
 	for _, reward := range resp.Data {
-		res := apiServer.Get(t, apiPrefix+"/rewards/"+reward.ID)
-		res.RequireOK(t)
+		require.True(t, reward.ID != "")
+		resSingleReward := apiServer.Get(t, apiPrefix+"/rewards/"+reward.ID)
+		resSingleReward.RequireOK(t)
 		var respLoop rewardResp
-		res.RequireUnmarshal(t, &respLoop)
+		resSingleReward.RequireUnmarshal(t, &respLoop)
 		require.Equal(t, 1, len(respLoop.Data))
 		rw, ok := insertedRewards[reward.Smesher]
 		require.True(t, ok)
+		respLoop.Data[0].ID = "" // this id generates by mongo, reset it. // todo probably bag, reward should have db independed id
 		require.Equal(t, rw, &respLoop.Data[0])
 	}
 }

--- a/tests/api/smeshers_test.go
+++ b/tests/api/smeshers_test.go
@@ -17,6 +17,7 @@ func TestSmeshersHandler(t *testing.T) { // /smeshers
 	for _, smesher := range resp.Data {
 		generatedSmesher, ok := generator.Smeshers[strings.ToLower(smesher.Id)]
 		require.True(t, ok)
+		smesher.Rewards = generatedSmesher.Rewards // for this endpoint we not calculate extra values, cause not use this field
 		require.Equal(t, generatedSmesher, &smesher)
 	}
 }

--- a/tests/collector/rewards_test.go
+++ b/tests/collector/rewards_test.go
@@ -29,6 +29,7 @@ func TestRewards(t *testing.T) {
 		tmpReward.Smesher = strings.ToLower(tmpReward.Smesher)
 		tmpReward.Coinbase = strings.ToLower(tmpReward.Coinbase)
 		generatedReward.Coinbase = strings.ToLower(generatedReward.Coinbase)
+		tmpReward.ID = "" // id is internal mongo id. before insert to db we do not know it.
 		require.Equal(t, *generatedReward, tmpReward)
 	}
 }

--- a/tests/collector/smeshers_test.go
+++ b/tests/collector/smeshers_test.go
@@ -31,6 +31,7 @@ func TestSmeshers(t *testing.T) {
 		generatedSmesher.CommitmentSize = uint64(size)
 		tmpSmesher.Coinbase = strings.ToLower(tmpSmesher.Coinbase)
 		generatedSmesher.Coinbase = strings.ToLower(generatedSmesher.Coinbase)
+		tmpSmesher.Rewards = generatedSmesher.Rewards // this is 0 cause it calculates from special mthod on api.
 		require.Equal(t, *generatedSmesher, tmpSmesher)
 	}
 }


### PR DESCRIPTION
closes #21 

reading from mongoDB moved to separated package `storagereader`. this allow use special user with read-only credentials, for serving api binary.

routing was simplified, minimum logic in routes - just parse parameter and provide it to service.
self-written wrappers for `http` will be dropped in separate pr

service contain some caching for requests which are happens often (`/network-info`)