### PR TITLE
Use correct version of go-spacemesh

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/spacemeshos/address v0.0.0-20220829090052-44ab32617871
 	github.com/spacemeshos/api/release/go v1.37.0
 	github.com/spacemeshos/go-scale v1.2.0
-	github.com/spacemeshos/go-spacemesh v1.5.2
+	github.com/spacemeshos/go-spacemesh v1.5.2-hotfix1
 	github.com/stretchr/testify v1.9.0
 	github.com/urfave/cli/v2 v2.27.1
 	go.mongodb.org/mongo-driver v1.10.1

--- a/go.sum
+++ b/go.sum
@@ -282,8 +282,8 @@ github.com/spacemeshos/fixed v0.1.1 h1:N1y4SUpq1EV+IdJrWJwUCt1oBFzeru/VKVcBsvPc2
 github.com/spacemeshos/fixed v0.1.1/go.mod h1:B/moObha9wGnwljZP+w/dYAwzv097aL9VV8Oyv2cM/E=
 github.com/spacemeshos/go-scale v1.2.0 h1:ZlA2L1ILym2gmyJUwUdLTiyP1ZIG0U4xE9nFVFLi83M=
 github.com/spacemeshos/go-scale v1.2.0/go.mod h1:HV6e3/X5h9u2aFpYKJxt7PY/fBuLBegEKWgeZJ+/5jE=
-github.com/spacemeshos/go-spacemesh v1.5.2 h1:VODStlD7teFke5MxZwP4SnYYRER1d80xRrqPdOXlDLY=
-github.com/spacemeshos/go-spacemesh v1.5.2/go.mod h1:yUitAjYjzjXk+CdFsA0Yy47dZa5LWUSfkfVPdL/V3XY=
+github.com/spacemeshos/go-spacemesh v1.5.2-hotfix1 h1:olMmES1BgbkHJpkZbjKHRpb7NdDfzIYGShXrNbhpmNs=
+github.com/spacemeshos/go-spacemesh v1.5.2-hotfix1/go.mod h1:agJTs0XXtFUJgsz0mVV+oNHRILvwjiL4AzuB9z+L0zI=
 github.com/spacemeshos/merkle-tree v0.2.3 h1:zGEgOR9nxAzJr0EWjD39QFngwFEOxfxMloEJZtAysas=
 github.com/spacemeshos/merkle-tree v0.2.3/go.mod h1:VomOcQ5pCBXz7goiWMP5hReyqOfDXGSKbrH2GB9Htww=
 github.com/spacemeshos/poet v0.10.2 h1:FVb0xgCFcjZyIGBQ92SlOZVx4KCmlCRRL4JSHL6LMGU=


### PR DESCRIPTION
## Motivation
Follow up to https://github.com/spacemeshos/explorer-backend/pull/147

## Changes
`v1.5.2-hotfix1` is the newest version of go-spacemesh with the CVE fix.

## Test Plan
n/a

## TODO
<!-- This section should be removed when all items are complete -->
- [x] Explain motivation or link existing issue(s)
- [x] Test changes and document test plan
- [x] Update documentation as needed

## DevOps Notes
<!-- Please uncheck these items as applicable to make DevOps aware of changes that may affect releases -->
- [x] This PR does not require configuration changes (e.g., environment variables, GitHub secrets, VM resources)
- [x] This PR does not affect public APIs
- [x] This PR does not rely on a new version of external services (PoET, elasticsearch, etc.)
- [x] This PR does not make changes to log messages (which monitoring infrastructure may rely on)
