### PR TITLE
EDIT: Add Authentication support on redis implementation.

### DIFF
--- a/api/cache/cache.go
+++ b/api/cache/cache.go
@@ -35,9 +35,11 @@ func New() *marshaler.Marshaler {
 	var manager *cache.MetricCache[any]
 	if RedisAddress != "" {
 		log.Info("using redis cache")
-		redisStore := redis_store.NewRedis(redis.NewClient(&redis.Options{
-			Addr: RedisAddress,
-		}), store.WithExpiration(Expiration))
+		opt, err := redis.ParseURL("redis://:qwerty@localhost:6379/1")
+		if err != nil {
+			panic(err)
+		}
+		redisStore := redis_store.NewRedis(redis.NewClient(opt), store.WithExpiration(Expiration))
 		manager = cache.NewMetric[any](
 			promMetrics,
 			cache.New[any](redisStore),

--- a/api/cache/cache.go
+++ b/api/cache/cache.go
@@ -35,7 +35,7 @@ func New() *marshaler.Marshaler {
 	var manager *cache.MetricCache[any]
 	if RedisAddress != "" {
 		log.Info("using redis cache")
-		opt, err := redis.ParseURL("redis://:qwerty@localhost:6379/1")
+		opt, err := redis.ParseURL(RedisAddress)
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
## Motivation
Because the migration to BM's, the redis now requires authentication.

## Changes
Change the redis connection from a raw string to redis.Parce

